### PR TITLE
Refresh package view on install/uninstall

### DIFF
--- a/usr/lib/linuxmint/mintInstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintInstall/mintinstall.py
@@ -181,6 +181,10 @@ class APTProgressHandler(threading.Thread):
                     for package in self.packages:
                         if package.pkg.name == pkg_name:
                             package.pkg = new_pkg
+                            # If the user is currently viewing this package in the browser,
+                            # refresh the view to show that the package has been installed or uninstalled.
+                            if self.application.navigation_bar.get_active().get_label() == pkg_name:
+                                self.application.show_package(package, None)
 
                     # Update apps tree                   
                     model_apps = self.wTree.get_widget("tree_applications").get_model()


### PR DESCRIPTION
Hello Linux Mint team,

I wrote this code so that if a user is currently looking at the page for a package
and the installation or removal of this package has just completed, the page will be refreshed
to reflect this change. (This is a feature that was in the Ubuntu Software Center that I liked).
