### PR TITLE
Add libgtk2-perl dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: mintinstall
 Architecture: all
-Depends: python (>= 2.4), python (<< 3), python-gtk2, python-glade2, mint-common, python-aptdaemon, python-webkit, python-imaging, ttf-freefont, python-sexy
+Depends: python (>= 2.4), python (<< 3), python-gtk2, python-glade2, mint-common, python-aptdaemon, python-webkit, python-imaging, ttf-freefont, python-sexy, libgtk2-perl
 Recommends: mintinstall-icons
 Description: Software Manager
  A software manager to easily install new applications.


### PR DESCRIPTION
No way to use KDE frontend with debconf due to missing perl's bindings.

So, it's better to use GTK frontend rather than dialog.
