### PR TITLE
Prepend gksu/kdesudo to command

### DIFF
--- a/usr/bin/mintInstall
+++ b/usr/bin/mintInstall
@@ -16,6 +16,6 @@ if len(sys.argv) > 1:
 else:
 	status = 9 # status code 9 is used to restart the app
 	while status == 9:
-		status = int(os.system("/usr/lib/linuxmint/mintInstall/mintinstall.py") / 256) # exit code is upper 8 bits
+		status = int(os.system("%s /usr/lib/linuxmint/mintInstall/mintinstall.py" % launcher) / 256) # exit code is upper 8 bits
 		
 

--- a/usr/bin/mintinstall
+++ b/usr/bin/mintinstall
@@ -16,6 +16,6 @@ if len(sys.argv) > 1:
 else:
 	status = 9 # status code 9 is used to restart the app
 	while status == 9:
-		status = int(os.system("/usr/lib/linuxmint/mintInstall/mintinstall.py") / 256) # exit code is upper 8 bits
+		status = int(os.system("%s /usr/lib/linuxmint/mintInstall/mintinstall.py" % launcher) / 256) # exit code is upper 8 bits
 		
 


### PR DESCRIPTION
Currently running "mintinstall" from alt-f2 will produce no visual indication of error (not running as root). This pull requests will automatically add gksu/kdesudo when calling /usr/lib/mintinstall/mintinstall.py to prompt user for root password.
