### PR TITLE
Faster search, faster startup, 160MB less memory usage

### DIFF
--- a/usr/lib/linuxmint/mintInstall/widgets/searchentry.py
+++ b/usr/lib/linuxmint/mintInstall/widgets/searchentry.py
@@ -33,7 +33,7 @@ class SearchEntry(sexy.IconEntry):
                                      gobject.TYPE_NONE,
                                      (gobject.TYPE_STRING,))}
 
-    SEARCH_TIMEOUT = 1000
+    SEARCH_TIMEOUT = 400
 
     def __init__(self, icon_theme=None):
         """


### PR DESCRIPTION
-Package search up to 50% faster (on top of last performance patch #23 )
-Memory usage reduced by 160MB
 --Removed overhead on package and review classes
 --Changed search caching from patch #23 after profiling showed some parts were unnecessary
-Mintinstall startup time reduced from 8380ms to 5200ms (in test VM)
-Bug fix, search occurs twice after pressing enter due to 'search while typing' callback
-'search while typing' timeout changed from 1000ms to 400ms, as the quick searches don't affect user's typing anymore.
