### PR TITLE
Error messages now shown after failed package installs, showing categories nearly 4x faster, and other fixes

### DIFF
--- a/usr/lib/linuxmint/mintInstall/mintinstall.glade
+++ b/usr/lib/linuxmint/mintInstall/mintinstall.glade
@@ -114,7 +114,7 @@
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkScrolledWindow" id="scrolledwindow4">
+                      <widget class="GtkScrolledWindow" id="tree_mixed_applications_scrolledview">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="hscrollbar_policy">automatic</property>


### PR DESCRIPTION
-An error message is now displayed when a package fails to install due to no internet, dpkg locks, etc. With tips on fixing the problem (I'm undecided on the wording, feel free to change), and the error details. Instead of silently failing leaving users guessing.
-Fixed: 'show_category' being called twice due issues with webkit title callback, this delayed viewing categories by over a second.
-Fixed: typos in _update_display (from my patch #23) causing refresh issues after a package was installed
-Fixed: scroll loading wasn't implemented on the subcategory view, causing results to be cut off
-Reduced initial package load for categories from 500 to 200 (same as search count). This is much more responsive, but relies more on the scroll loading. (This value might need some more tweaking)
