### PR TITLE
Fix the placement of scrollbar

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -497,6 +497,9 @@ class Application():
         self.builder.get_object("menubar1").append(helpMenu)
 
         self.flowbox_applications = Gtk.FlowBox()
+        self.flowbox_applications.set_margin_start(12)
+        self.flowbox_applications.set_margin_end(12)
+        self.flowbox_applications.set_margin_top(6)
         self.flowbox_applications.set_min_children_per_line(1)
         self.flowbox_applications.set_max_children_per_line(3)
         self.flowbox_applications.set_row_spacing(6)

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -271,8 +271,6 @@
                       <object class="GtkScrolledWindow" id="scrolledwindow_applications">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="margin_left">6</property>
-                        <property name="margin_right">6</property>
                         <child>
                           <placeholder/>
                         </child>


### PR DESCRIPTION
We have margins set on the scrolledwindow_applications object. This causes the
scrollbar to get pushed in off the side of the window. Move the margins to the
child flowbox instead so the scrollbar is neatly against the window edge and
doesn't partially cover the content when hovered.