### PR TITLE
subcategories: Ensure the "All" category is selected initially

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1253,6 +1253,7 @@ class Application():
         if len(category.subcategories) > 0:
             row = CategoryListBoxRow(category, is_all=True)
             self.listbox_categories.add(row)
+            self.listbox_categories.select_row(row)
 
             for cat in category.subcategories:
                 row = CategoryListBoxRow(cat)


### PR DESCRIPTION
This also fixes an issue where the category wasn't highlighted when selecting
it.