### PR TITLE
Make installation and removal a bit more user friendly

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1089,7 +1089,6 @@ class Application():
     def flatpak_progress_cb(self, status, progress, estimating, package):
         print (status, progress, estimating, package)
         if self.current_package is not None and self.current_package.pkg_name == package.pkg_name:
-            self.builder.get_object("notebook_progress").set_current_page(self.PROGRESS_TAB)
             self.builder.get_object("application_progress").set_fraction(progress / 100.0)
             XApp.set_window_progress(self.main_window, progress)
 
@@ -1114,6 +1113,9 @@ class Application():
 
     @async
     def flatpak_install(self, package):
+        if self.current_package is not None and self.current_package.pkg_name == package.pkg_name:
+            self.builder.get_object("notebook_progress").set_current_page(self.PROGRESS_TAB)
+
         self.flatpak_installation.install(package.remote, Flatpak.RefKind.APP, package.pkg_name, package.arch, package.branch, self.flatpak_progress_cb, package)
         # Call flatpak update on the newly installed package
         # to trigger the installation of missing dependencies
@@ -1737,6 +1739,8 @@ class Application():
         # Load package info
         score = 0
 
+        progress_label = self.builder.get_object("application_progress_label")
+
         action_button = self.builder.get_object("action_button")
         style_context = action_button.get_style_context()
         if package.is_installed():
@@ -1745,6 +1749,7 @@ class Application():
             style_context.add_class("destructive-action")
             action_button_description = _("Installed")
             action_button.set_sensitive(True)
+            progress_label.set_text(_("Removing"))
         else:
             if package.pkg_name in BROKEN_PACKAGES:
                 action_button_label = _("Not available")
@@ -1758,6 +1763,7 @@ class Application():
                 style_context.add_class("suggested-action")
                 action_button_description = _("Not installed")
                 action_button.set_sensitive(True)
+                progress_label.set_text(_("Installing"))
 
         apt_specific_widgets = ["label_package", "application_package", "label_size", "application_size", "label_version", "application_version"]
         flatpak_specific_widgets = ["label_flatpak", "application_flatpak", "label_remote", "application_remote", "label_branch", "application_branch", "label_architecture", "application_architecture"]

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -524,6 +524,7 @@
                                   <object class="GtkBox" id="box9">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
+                                    <property name="margin_right">5</property>
                                     <property name="spacing">6</property>
                                     <child>
                                       <object class="GtkButton" id="launch_button">
@@ -531,6 +532,8 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
+                                        <property name="valign">center</property>
+                                        <property name="vexpand">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -543,6 +546,8 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
+                                        <property name="valign">center</property>
+                                        <property name="vexpand">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
@@ -561,6 +566,21 @@
                                     <property name="can_focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
+                                      <object class="GtkLabel" id="application_progress_label">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Installing</property>
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkProgressBar" id="application_progress">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
@@ -568,7 +588,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">0</property>
+                                        <property name="position">1</property>
                                       </packing>
                                     </child>
                                   </object>
@@ -580,11 +600,38 @@
                                   <placeholder/>
                                 </child>
                                 <child>
-                                  <object class="GtkSpinner" id="spinner_progress">
+                                  <object class="GtkBox" id="box12">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Please wait. Flatpak runtime dependencies are being installed.</property>
-                                    <property name="active">True</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">4</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label1">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">Installing additional dependencies</property>
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinner" id="spinner_progress">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="active">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="position">2</property>


### PR DESCRIPTION
* Add labels to the install/remove progress bar
* Add a label to the progress spinner when installing flatpak dependencies
* Flatpaks can be a bit slow to start installing. Switch to showing the
install progress bar sooner to give the user an indication that it's actually
working.