### PR TITLE
Reduce the vertical size of the window

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -276,7 +276,7 @@ class FeatureTile(Gtk.Button):
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
         vbox.set_border_width(6)
 
-        vbox.pack_start(Gtk.Label(), False, False, 50)
+        vbox.pack_start(Gtk.Label(), False, False, 30)
         vbox.pack_start(label_name, False, False, 0)
         vbox.pack_start(label_summary, True, True, 0)
 

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -147,26 +147,8 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel" id="label2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="ypad">6</property>
-                    <property name="label" translatable="yes">Featured application</property>
-                    <property name="xalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                      <attribute name="scale" value="1.2"/>
-                    </attributes>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkBox" id="box_featured">
-                    <property name="height_request">200</property>
+                    <property name="height_request">180</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>


### PR DESCRIPTION
Users are having issues on monitors with a height of 768. Remove the unneeded
"Featured Application" label. Also reduce the height of the banner by 20px.
This brings the overall height to less than 700px.