### PR TITLE
 Remove minitube from editors picks as it is broken

### DIFF
--- a/usr/share/linuxmint/mintinstall/categories/picks-kde.list
+++ b/usr/share/linuxmint/mintinstall/categories/picks-kde.list
@@ -14,7 +14,6 @@ thunderbird
 vlc
 cheese
 mpv
-minitube
 xfburn
 gimp
 inkscape

--- a/usr/share/linuxmint/mintinstall/categories/picks.list
+++ b/usr/share/linuxmint/mintinstall/categories/picks.list
@@ -16,7 +16,6 @@ thunderbird
 vlc
 cheese
 mpv
-minitube
 gimp
 inkscape
 blender


### PR DESCRIPTION
Fix would be adding the latest version to upstream
http://flavio.tordini.org/minitube