### PR TITLE
Use HEAD request to check new-reviews file size

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -129,21 +129,23 @@ class DownloadReviews(threading.Thread):
 
     def run(self):
         try:
-            print("Checking new reviews")
+            print("Checking for new reviews")
             reviews_path_tmp = REVIEWS_PATH + ".tmp"
-            urllib.request.urlretrieve("https://community.linuxmint.com/data/new-reviews.list", reviews_path_tmp)
             size = 0
             new_size = 0
+            reviews_url = "https://community.linuxmint.com/data/new-reviews.list"
             if os.path.exists(REVIEWS_PATH):
                 size = os.path.getsize(REVIEWS_PATH)
-            if os.path.exists(reviews_path_tmp):
-                new_size = os.path.getsize(reviews_path_tmp)
-                if size != new_size:
-                    os.system("mv " + reviews_path_tmp + " " + REVIEWS_PATH)
-                    print("Overwriting reviews file in %s" % REVIEWS_PATH)
-                    self.application.update_reviews()
-                else:
-                    print("No new reviews")
+            new_size = urllib.request.urlopen(reviews_url).info()['content-length']
+            if size != int(new_size):
+                print("Local reviews size: " + str(size) + ". Remote reviews size: " + new_size)
+                print("Downloading new reviews")
+                urllib.request.urlretrieve(reviews_url, reviews_path_tmp)
+                print("Overwriting reviews file in %s" % REVIEWS_PATH)
+                os.system("mv " + reviews_path_tmp + " " + REVIEWS_PATH)
+                self.application.update_reviews()
+            else:
+                print("No new reviews")
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
We can use the "Content-Length" header from a HEAD request to quickly check the file size of the remote reviews.list and only download the whole file if it's different from the local reviews.list's file size.

This would save over 5 MBs (and growing) of network traffic if the local list is up to date.

[Small gist](https://gist.github.com/milangfx/8ce01d148e9cde95692057701f5b58e8) to check the load time of the different methods.