### PR TITLE
Split ui code from package management

### DIFF
--- a/usr/bin/mintinstall-fp-handler
+++ b/usr/bin/mintinstall-fp-handler
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import subprocess
+import sys
+
+subprocess.call(["/usr/lib/linuxmint/mintinstall/mintinstall.py", "install"] + sys.argv[1:])

--- a/usr/bin/mintinstall-remove-app
+++ b/usr/bin/mintinstall-remove-app
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+
+import subprocess
+import sys
+
+subprocess.call(["/usr/lib/linuxmint/mintinstall/mintinstall-remove-app.py"] + sys.argv[1:])

--- a/usr/bin/mintinstall-update-pkgcache
+++ b/usr/bin/mintinstall-update-pkgcache
@@ -1,0 +1,5 @@
+#!/usr/bin/python3
+
+import subprocess
+
+subprocess.call("/usr/lib/linuxmint/mintinstall/mintinstall-update-pkgcache.py")

--- a/usr/lib/linuxmint/mintinstall/housekeeping.py
+++ b/usr/lib/linuxmint/mintinstall/housekeeping.py
@@ -1,0 +1,43 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import gi
+from gi.repository import GLib
+
+import time
+import os
+import threading
+import multiprocessing
+from pathlib import Path
+
+SCREENSHOT_DIR = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "screenshots")
+
+MAX_AGE = 14 * (60 * 60 * 24) # days
+
+def run():
+    print("MintInstall: deleting old screenshots")
+
+    thread = threading.Thread(target=_clean_screenshots_thread)
+    thread.start()
+
+def _clean_screenshots_thread():
+    proc = multiprocessing.Process(target=_clean_screenshots_process)
+
+    proc.start()
+    proc.join()
+
+def _clean_screenshots_process():
+    ss_location = Path(SCREENSHOT_DIR)
+
+    screenshots = ss_location.glob("*.*")
+
+    for p in screenshots:
+        try:
+            mtime = os.path.getmtime(p)
+
+            if (time.time() - MAX_AGE) > mtime:
+                p.unlink()
+        except OSError:
+            pass
+

--- a/usr/lib/linuxmint/mintinstall/housekeeping.py
+++ b/usr/lib/linuxmint/mintinstall/housekeeping.py
@@ -2,7 +2,6 @@ import sys
 if sys.version_info.major < 3:
     raise "python3 required"
 
-import gi
 from gi.repository import GLib
 
 import time
@@ -16,7 +15,7 @@ SCREENSHOT_DIR = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "screens
 MAX_AGE = 14 * (60 * 60 * 24) # days
 
 def run():
-    print("MintInstall: deleting old screenshots")
+    print("MintInstall: Deleting old screenshots")
 
     thread = threading.Thread(target=_clean_screenshots_thread)
     thread.start()

--- a/usr/lib/linuxmint/mintinstall/installer/_apt.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_apt.py
@@ -1,0 +1,317 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import gi
+gi.require_version('AppStream', '1.0')
+gi.require_version('Gtk', '3.0')
+from gi.repository import GObject, Gtk
+import apt
+import time
+import threading
+import dbus
+
+import aptdaemon.client
+from aptdaemon.gtk3widgets import AptErrorDialog, AptProgressDialog
+import aptdaemon.errors
+
+from installer.pkgInfo import AptPkgInfo
+from installer.dialogs import ChangesConfirmDialog
+
+# List of packages which are either broken or do not install properly in mintinstall
+BROKEN_PACKAGES = ['pepperflashplugin-nonfree']
+
+# List extra packages that aren't necessarily marked in their control files, but
+# we know better...
+CRITICAL_PACKAGES = ["mint-common", "mint-meta-core", "mintdesktop"]
+
+def capitalize(string):
+    if len(string) > 1:
+        return (string[0].upper() + string[1:])
+    else:
+        return (string)
+
+_apt_cache = None
+_apt_cache_lock = threading.Lock()
+_as_pool = None
+
+def get_apt_cache(full=False):
+    global _apt_cache
+
+    if full or (not _apt_cache):
+        with _apt_cache_lock:
+            _apt_cache = apt.Cache()
+
+    return _apt_cache
+
+def add_prefix(name):
+    return "apt:%s" % (name)
+
+def make_pkg_hash(apt_pkg):
+    if not isinstance(apt_pkg, apt.Package):
+        raise TypeError("apt.make_pkg_hash_make must receive apt.Package, not %s" % type(apt_pkg))
+
+    return add_prefix(apt_pkg.name)
+
+def process_full_apt_cache(cache):
+    apt_time = time.time()
+    apt_cache = get_apt_cache()
+
+    sections = {}
+
+    keys = apt_cache.keys()
+
+    for key in keys:
+        name = apt_cache[key].name
+
+        if name.startswith("lib") and not name.startswith("libreoffice"):
+            continue
+        if name.endswith(":i386") and name != "steam:i386":
+            continue
+        if name.endswith("-dev"):
+            continue
+        if name.endswith("-dbg"):
+            continue
+        if name.endswith("-doc"):
+            continue
+        if name.endswith("-common"):
+            continue
+        if name.endswith("-data"):
+            continue
+        if "-locale-" in name:
+            continue
+        if "-l10n-" in name:
+            continue
+        if name.endswith("-dbgsym"):
+            continue
+        if name.endswith("l10n"):
+            continue
+        if name.endswith("-perl"):
+            continue
+        if ":" in name and name.split(":")[0] in keys:
+            continue
+
+        pkg = apt_cache[key]
+
+        pkg_hash = make_pkg_hash(pkg)
+
+        if pkg.section:
+            section_string = pkg.section
+
+            if "/" in section_string:
+                section = section_string.split("/")[1]
+            else:
+                section = section_string
+
+        try:
+            sections[section].append(pkg_hash)
+        except Exception:
+            sections[section] = []
+            sections[section].append(pkg_hash)
+
+        cache[pkg_hash] = AptPkgInfo(pkg_hash, pkg)
+
+    print('apt cache took %0.3f s' % ((time.time() - apt_time) * 1000.0))
+
+    return cache, sections
+
+# def initialize_appstream():
+#     global _as_pool
+
+#     if _as_pool == None:
+#         pool = AppStream.Pool()
+#         pool.set_cache_flags(AppStream.CacheFlags.NONE)
+#         pool.load()
+#         _as_pool = pool
+
+def search_for_pkginfo_apt_pkg(pkginfo):
+    name = pkginfo.name
+
+    apt_cache = get_apt_cache()
+
+    try:
+        return apt_cache[name]
+    except:
+        return None
+
+def find_pkginfo(cache, string):
+    try:
+        pkginfo = cache[add_prefix(string)]
+    except:
+        pkginfo = None
+
+    return pkginfo
+
+def pkginfo_is_installed(pkginfo):
+    global _apt_cache_lock
+    apt_cache = get_apt_cache()
+
+    with _apt_cache_lock:
+        try:
+            return apt_cache[pkginfo.name].installed != None
+        except:
+            return False
+
+def select_packages(task):
+    thread = threading.Thread(target=_calculate_apt_changes, args=(task,))
+    thread.start()
+
+def _is_critical_package(pkg):
+    try:
+        if pkg.essential or pkg.versions[0].priority == "required" or pkg.name in CRITICAL_PACKAGES:
+            return True
+        else:
+            return False
+    except Exception:
+        return False
+
+def _calculate_apt_changes(task):
+    global _apt_cache_lock
+    apt_cache = get_apt_cache()
+
+    with _apt_cache_lock:
+        apt_cache.clear()
+
+        pkginfo = task.pkginfo
+
+        aptpkg = apt_cache[pkginfo.name]
+
+        try:
+            if aptpkg.is_installed:
+                aptpkg.mark_delete(True, True)
+            else:
+                aptpkg.mark_install()
+        except:
+            if aptpkg.name not in BROKEN_PACKAGES:
+                BROKEN_PACKAGES.append(aptpkg.name)
+
+        changes = apt_cache.get_changes()
+
+        for pkg in changes:
+            if pkg.marked_install:
+                task.to_install.append(pkg.name)
+            elif pkg.marked_upgrade:
+                task.to_update.append(pkg.name)
+            elif pkg.marked_delete:
+                task.to_remove.append(pkg.name)
+
+        task.download_size = apt_cache.required_download
+
+        space = apt_cache.required_space
+
+        if space < 0:
+            task.freed_size = space * -1
+            task.install_size = 0
+        else:
+            task.freed_size = 0
+            task.install_size = space
+
+        for pkg_name in task.to_remove:
+            if _is_critical_package(apt_cache[pkg_name]):
+                print("Cannot remove critical package: %s" % pkg_name)
+                task.info_ready_status = task.STATUS_FORBIDDEN
+
+        if aptpkg.name in BROKEN_PACKAGES:
+            print("Cannot execute task, package is broken: %s" % aptpkg.name)
+            task.info_ready_status = task.STATUS_BROKEN
+
+        print("For install:", task.to_install)
+        print("For removal:", task.to_remove)
+        print("For upgrade:", task.to_update)
+
+        if task.info_ready_status not in (task.STATUS_FORBIDDEN, task.STATUS_BROKEN):
+            task.info_ready_status = task.STATUS_OK
+            task.execute = execute_transaction
+
+    GObject.idle_add(task.info_ready_callback, task)
+
+def sync_cache_installed_states():
+    get_apt_cache(full=True)
+
+def execute_transaction(task):
+    if task.client_progress_cb != None:
+        task.has_window = True
+
+    task.transaction = MetaTransaction(task)
+
+class MetaTransaction():
+    def __init__(self, task):
+        self.apt_client = aptdaemon.client.AptClient()
+        self.task = task
+        self.apt_transaction = None
+
+        if task.type == "remove":
+            self.apt_client.remove_packages([task.pkginfo.name],
+                                            reply_handler=self._calculate_changes,
+                                            error_handler=self._on_error) # dbus.DBusException
+        else:
+            self.apt_client.install_packages([task.pkginfo.name],
+                                             reply_handler=self._calculate_changes,
+                                             error_handler=self._on_error) # dbus.DBusException
+
+    def _calculate_changes(self, apt_transaction):
+        self.apt_transaction = apt_transaction
+        self.apt_transaction.set_debconf_frontend("gnome")
+
+        self.apt_transaction.simulate(reply_handler=self._confirm_changes,
+                                      error_handler=self._on_error) # aptdaemon.errors.TransactionFailed, dbus.DBusException
+
+    def _confirm_changes(self):
+        try:
+            if [pkgs for pkgs in self.apt_transaction.dependencies if pkgs]:
+                dia = ChangesConfirmDialog(self.apt_transaction, self.task)
+                res = dia.run()
+                dia.hide()
+                if res != Gtk.ResponseType.OK:
+                    GObject.idle_add(self.task.finished_cleanup_cb, self.task)
+                    return
+            self._run_transaction()
+        except Exception as e:
+            print(e)
+
+    def _on_error(self, error):
+        if self.apt_transaction.error_code == "error-not-authorized":
+            # Silently ignore auth failures
+
+            self.task.error_message = None # Should already be none, but this is a reminder
+            return
+        elif not isinstance(error, aptdaemon.errors.TransactionFailed):
+            # Catch internal errors of the client
+            error = aptdaemon.errors.TransactionFailed(aptdaemon.enums.ERROR_UNKNOWN,
+                                                       str(error))
+
+        if self.task.progress_state != self.task.PROGRESS_STATE_FAILED:
+            self.task.progress_state = self.task.PROGRESS_STATE_FAILED
+
+            self.task.error_message = self.apt_transaction.error_details
+
+            dia = AptErrorDialog(error)
+            dia.run()
+            dia.hide()
+            GObject.idle_add(self.task.error_cleanup_cb, self.task)
+
+    def _run_transaction(self):
+        self.apt_transaction.connect("finished", self.on_transaction_finished)
+
+        if self.task.has_window:
+            self.apt_transaction.connect("progress-changed", self.on_transaction_progress)
+            self.apt_transaction.connect("error", self.on_transaction_error)
+            self.apt_transaction.run(reply_handler=lambda: None, error_handler=self._on_error)
+        else:
+            progress_window = AptProgressDialog(self.apt_transaction)
+            progress_window.run(show_error=False, error_handler=self._on_error)
+
+    def on_transaction_progress(self, apt_transaction, progress):
+        if not apt_transaction.error:
+            self.task.client_progress_cb(self.task.pkginfo, progress, False)
+
+    def on_transaction_error(self, apt_transaction, error_code, error_details):
+        if self.task.progress_state != self.task.PROGRESS_STATE_FAILED:
+            self._on_error(apt_transaction.error)
+
+    def on_transaction_finished(self, apt_transaction, exit_state):
+        # finished signal is always called whether successful or not
+        # Only call here if we succeeded, to prevent multiple calls
+        if (exit_state == aptdaemon.enums.EXIT_SUCCESS) or apt_transaction.error_code == "error-not-authorized":
+            self.task.progress_state = self.task.PROGRESS_STATE_FINISHED
+            GObject.idle_add(self.task.finished_cleanup_cb, self.task)

--- a/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
@@ -1,0 +1,736 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import gi
+gi.require_version('AppStream', '1.0')
+from gi.repository import AppStream, Flatpak, GLib, GObject, Gtk, Gio
+import time
+import threading
+import math
+
+from installer.pkgInfo import FlatpakPkgInfo
+
+from installer import dialogs
+from installer.dialogs import ChangesConfirmDialog, FlatpakProgressWindow
+
+_fp_sys = None
+
+_as_pool_lock = threading.Lock()
+_as_pools = {} # keyed to remote name
+
+def print_timing(func):
+    def wrapper(*arg):
+        t1 = time.time()
+        res = func(*arg)
+        t2 = time.time()
+        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
+        return res
+    return wrapper
+
+def get_fp_sys():
+    global _fp_sys
+
+    if _fp_sys == None:
+        _fp_sys = Flatpak.Installation.new_system(None)
+
+    return _fp_sys
+
+ALIASES = {
+    "org.gnome.Weather" : "org.gnome.Weather.Application"
+}
+
+def make_pkg_hash(ref):
+    if not isinstance(ref, Flatpak.Ref):
+        raise TypeError("flatpak.make_pkg_hash() must receive FlatpakRef, not %s" % type(ref))
+
+    try:
+        return "fp:%s:%s" % (ref.get_origin(), ref.format_ref())
+    except Exception:
+        return "fp:%s:%s" % (ref.get_remote_name(), ref.format_ref())
+
+def _get_file_timestamp(gfile):
+    try:
+        info = gfile.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
+
+        return info.get_attribute_uint64("time::modified")
+    except GLib.Error as e:
+        if e.code != Gio.IOErrorEnum.NOT_FOUND:
+            print("_flatpak: could not get time::modified from file %s" % gfile.get_path())
+        return 0
+
+def _should_update_appstream_data(fp_sys, remote, arch):
+    ret = False
+
+    current_timestamp = _get_file_timestamp(remote.get_appstream_timestamp(arch))
+
+    try:
+        if fp_sys.update_remote_sync(remote.get_name(), None):
+            print("_flatpak: metadata for remote '%s' has been updated. Comparing appstream timestamps..." % remote.get_name())
+
+            new_timestamp = _get_file_timestamp(remote.get_appstream_timestamp(arch))
+
+            if (new_timestamp > current_timestamp) or (current_timestamp == 0):
+                ret = True
+    except GLib.Error as e:
+        print("_flatpak: could not update metadata for remote '%s': %s" % (remote.get_name(), e.message))
+
+    return ret
+
+def _process_remote(cache, fp_sys, remote, arch, force_noenumerate=False):
+    remote_name = remote.get_name()
+
+    if remote.get_disabled():
+        print("_flatpak: remote '%s' is disabled, skipping" % remote_name)
+        return
+
+    remote_url = remote.get_url()
+
+    if _should_update_appstream_data(fp_sys, remote, arch):
+        print("_flatpak: new appstream data available for remote '%s', fetching..." % remote_name)
+
+        try:
+            fp_sys.update_appstream_sync(remote_name, arch, None)
+        except GLib.Error:
+            # Not fatal..
+            pass
+    else:
+        print("_flatpak: no new appstream data for remote '%s', skipping download" % remote_name)
+
+    # get_no_enumerate indicates whether a remote should be used to list applications.
+    # Instead, they're intended for single downloads (via .flatpakref files)
+    if remote.get_noenumerate() or force_noenumerate:
+        print("_flatpak: remote '%s' is marked as no-enumerate (or we're working on a .flatpakref file,) skipping package listing" % remote_name)
+        return
+
+    try:
+        for ref in fp_sys.list_remote_refs_sync(remote_name, None):
+            if ref.get_kind() != Flatpak.RefKind.APP:
+                continue
+
+            if ref.get_arch() != arch:
+                continue
+
+            _add_package_to_cache(cache, ref, remote_url, False)
+    except GLib.Error as e:
+        print(e.message)
+
+def _add_package_to_cache(cache, ref, remote_url, installed):
+    pkg_hash = make_pkg_hash(ref)
+
+    try:
+        remote_name = ref.get_remote_name()
+    except Exception:
+        remote_name = ref.get_origin()
+
+    try:
+        pkginfo = cache[pkg_hash]
+
+        if installed:
+            pkginfo.installed = installed
+    except KeyError:
+        pkginfo = FlatpakPkgInfo(pkg_hash, remote_name, ref, remote_url, installed)
+        cache[pkg_hash] = pkginfo
+
+    return pkginfo
+
+def process_full_flatpak_installation(cache):
+    fp_time = time.time()
+
+    arch = Flatpak.get_default_arch()
+    fp_sys = Flatpak.Installation.new_system(None)
+
+    try:
+        for remote in fp_sys.list_remotes():
+            _process_remote(cache, fp_sys, remote, arch)
+
+            try:
+                remote_name = remote.get_name()
+
+                for ref in fp_sys.list_installed_refs_by_kind(Flatpak.RefKind.APP, None):
+                    # All remotes will see installed refs, but the installed refs will always
+                    # report their correct origin, so only add installed refs when they match the remote.
+                    if ref.get_origin() == remote_name:
+                        _add_package_to_cache(cache, ref, remote.get_url(), True)
+            except GLib.Error as e:
+                print(e.message)
+
+    except GLib.Error as e:
+        print("Could not get remote list", e.message)
+        cache = {}
+
+    print('flatpaks took %0.3f s' % ((time.time() - fp_time) * 1000.0))
+
+    return cache
+
+def _load_appstream_pool(pools, remote):
+    pool = AppStream.Pool()
+    pool.add_metadata_location(remote.get_appstream_dir().get_path())
+    pool.set_cache_flags(AppStream.CacheFlags.NONE)
+    pool.load()
+    pools[remote.get_name()] = pool
+
+def initialize_appstream():
+    thread = threading.Thread(target=_initialize_appstream_thread)
+    thread.start()
+
+def _initialize_appstream_thread():
+    fp_sys = get_fp_sys()
+
+    global _as_pools
+    global _as_pool_lock
+
+    with _as_pool_lock:
+        _as_pools = {}
+
+        try:
+            for remote in fp_sys.list_remotes():
+                _load_appstream_pool(_as_pools, remote)
+        except GLib.Error:
+            print("Could not initialize appstream components for flatpaks")
+
+def search_for_pkginfo_as_component(pkginfo):
+    name = pkginfo.name
+
+    comps = []
+
+    global _as_pools
+    global _as_pool_lock
+
+    with _as_pool_lock:
+        try:
+            pool = _as_pools[pkginfo.remote]
+        except Exception:
+            return None
+
+        comps = pool.get_components_by_id(name + ".desktop")
+
+        if comps == []:
+            if name in ALIASES.keys():
+                comps = pool.get_components_by_id(ALIASES[name] + ".desktop")
+            else:
+                comps = pool.get_components_by_id(name)
+
+    if len(comps) > 0:
+        return comps[0]
+    else:
+        return None
+
+def _is_ref_installed(fp_sys, remote, ref):
+    try:
+        iref = fp_sys.get_installed_ref(ref.get_kind(),
+                                        ref.get_name(),
+                                        ref.get_arch(),
+                                        ref.get_branch(),
+                                        None)
+
+        if iref:
+            return True
+    except GLib.Error:
+        pass
+    except AttributeError: # bad/null ref
+        pass
+
+    return False
+
+def _get_remote_sizes(fp_sys, remote, ref):
+    try:
+        success, dl_s, inst_s = fp_sys.fetch_remote_size_sync(remote,
+                                                              ref,
+                                                              None)
+    except GLib.Error:
+        # Not fatal?
+        dl_s = 0
+        inst_s = 0
+
+    return dl_s, inst_s
+
+def _get_installed_size(fp_sys, ref):
+    if isinstance(ref, Flatpak.InstalledRef):
+        return ref.get_installed_size()
+    else:
+        try:
+            iref = fp_sys.get_installed_ref(ref.get_kind(),
+                                            ref.get_name(),
+                                            ref.get_arch(),
+                                            ref.get_branch(),
+                                            None)
+            return iref.get_installed_size()
+        except GLib.Error as e:
+            # This isn't fatal I guess?
+            return 0
+
+def _add_ref_to_task(fp_sys, task, ref, needs_update=False):
+    if task.type == "install":
+        if needs_update:
+            task.to_update.append(ref.format_ref())
+        else:
+            task.to_install.append(ref.format_ref())
+
+        dl_s, inst_s = _get_remote_sizes(fp_sys, task.remote, ref)
+
+        task.download_size += dl_s
+        task.install_size = inst_s
+    elif task.type == "remove":
+        task.to_remove.append(ref.format_ref())
+        task.freed_size += _get_installed_size(fp_sys, ref)
+    else:
+        task.to_update.append(ref.format_ref())
+
+        current_inst_s = _get_installed_size(fp_sys, ref)
+        remote_dl_s, remote_inst_s = _get_remote_sizes(fp_sys, task.remote, ref)
+
+        task.download_size += remote_dl_s
+
+        if current_inst_s < remote_inst_s:
+            task.install_size += remote_inst_s - current_inst_s
+        else:
+            task.freed_size += current_inst_s - remote_inst_s
+
+def _get_runtime_ref(fp_sys, remote_name, ref):
+    runtime_ref = None
+
+    try:
+        meta = fp_sys.fetch_remote_metadata_sync(remote_name, ref, None)
+
+        keyfile = GLib.KeyFile.new()
+
+        data = meta.get_data().decode()
+        keyfile.load_from_data(data, len(data), GLib.KeyFileFlags.NONE)
+
+        runtime = keyfile.get_string("Application", "runtime")
+        basic_ref = Flatpak.Ref.parse("runtime/%s" % runtime)
+
+        try:
+            # prefer the same-remote's runtimes
+            runtime_ref = fp_sys.fetch_remote_ref_sync(remote_name,
+                                                       basic_ref.get_kind(),
+                                                       basic_ref.get_name(),
+                                                       basic_ref.get_arch(),
+                                                       basic_ref.get_branch(),
+                                                       None)
+        except GLib.Error as e:
+            # check other remotes if this fails
+            for other_remote in fp_sys.list_remotes():
+                other_remote_name = other_remote.get_name()
+
+                if other_remote_name == remote_name:
+                    continue
+
+                try:
+                    runtime_ref = fp_sys.fetch_remote_ref_sync(other_remote_name,
+                                                               basic_ref.get_kind(),
+                                                               basic_ref.get_name(),
+                                                               basic_ref.get_arch(),
+                                                               basic_ref.get_branch(),
+                                                               None)
+                    break
+                except GLib.Error as e:
+                    continue
+    except GLib.Error as e:
+        raise Exception("Could not determine runtime info for app: %s" % e.message)
+
+    return runtime_ref
+
+def _get_remote_related_refs(fp_sys, remote, ref):
+    related_refs = []
+
+    try:
+        related_refs = fp_sys.list_remote_related_refs_sync(remote, ref.format_ref(), None)
+    except GLib.Error as e:
+        raise Exception("Could not determine remote related refs for app: %s" % e.message)
+
+    return related_refs
+
+def _get_installed_related_refs(fp_sys, remote, ref):
+    related_refs = []
+
+    try:
+        related_refs = fp_sys.list_installed_related_refs_sync(remote, ref.format_ref(), None)
+    except GLib.Error as e:
+        raise Exception("Could not determine installed refs for app: %s" % e.message)
+
+    return related_refs
+
+def select_updates(task):
+    thread = threading.Thread(target=_select_updates_thread, args=(task,))
+    thread.start()
+
+def _select_updates_thread(task):
+    fp_sys = get_fp_sys()
+
+    try:
+        updates = fp_sys.list_installed_refs_for_update(None)
+    except GLib.Error as e:
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        if task.info_ready_callback:
+            GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    for ref in updates:
+        _add_ref_to_task(fp_sys, task, ref, needs_update=True)
+
+    if len(task.to_update) > 0:
+        print("flatpaks that can be updated:")
+        for ref in task.to_update:
+            print(ref)
+
+        task.info_ready_status = task.STATUS_OK
+        task.execute = execute_transaction
+    else:
+        print("no updated flatpaks")
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def select_packages(task):
+    method = None
+
+    if task.type == "install":
+        method = _pick_refs_for_installation
+    else:
+        method = _pick_refs_for_removal
+
+    thread = threading.Thread(target=method, args=(task,))
+    thread.start()
+
+def _pick_refs_for_installation(task):
+    fp_sys = get_fp_sys()
+
+    pkginfo = task.pkginfo
+    refid = pkginfo.refid
+
+    # We don't need a real RemoteRef to pass to add_ref_to_task, the disk space calls go thru
+    # fp_sys
+    ref = Flatpak.Ref.parse(refid)
+    remote_name = pkginfo.remote
+
+    _add_ref_to_task(fp_sys, task, ref)
+
+    try:
+        update_list = fp_sys.list_installed_refs_for_update(None)
+
+        runtime_ref = _get_runtime_ref(fp_sys, remote_name, ref)
+
+        if not _is_ref_installed(fp_sys, remote_name, runtime_ref):
+            _add_ref_to_task(fp_sys, task, runtime_ref)
+        else:
+            if runtime_ref in update_list:
+                _add_ref_to_task(fp_sys, task, runtime_ref, needs_update=True)
+
+        all_related_refs = _get_remote_related_refs(fp_sys, remote_name, ref)
+        all_related_refs += _get_remote_related_refs(fp_sys, remote_name, runtime_ref)
+
+        for related_ref in all_related_refs:
+            if (not _is_ref_installed(fp_sys, remote_name, related_ref)) and related_ref.should_download():
+                _add_ref_to_task(fp_sys, task, related_ref)
+            else:
+                if related_ref in update_list:
+                    _add_ref_to_task(fp_sys, task, related_ref, needs_update=True)
+
+    except Exception as e:
+        # Something went wrong, bail out
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        if task.info_ready_callback:
+            GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    print("For installation:")
+    for ref in task.to_install:
+        print(ref)
+
+    task.info_ready_status = task.STATUS_OK
+    task.execute = execute_transaction
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def _pick_refs_for_removal(task):
+    fp_sys = get_fp_sys()
+
+    pkginfo = task.pkginfo
+
+    try:
+        ref = fp_sys.get_installed_ref(pkginfo.kind,
+                                       pkginfo.name,
+                                       pkginfo.arch,
+                                       pkginfo.branch,
+                                       None)
+
+        remote = pkginfo.remote
+
+        _add_ref_to_task(fp_sys, task, ref)
+
+        related_refs = _get_installed_related_refs(fp_sys, remote, ref)
+
+        for related_ref in related_refs:
+            if _is_ref_installed(fp_sys, remote, related_ref) and related_ref.should_delete():
+                _add_ref_to_task(fp_sys, task, related_ref)
+
+    except Exception as e:
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    print("For removal:")
+    for ref in task.to_remove:
+        print(ref)
+
+    task.info_ready_status = task.STATUS_OK
+    task.execute = execute_transaction
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def list_updated_pkginfos(cache):
+    fp_sys = get_fp_sys()
+
+    updated = []
+
+    try:
+        updates = fp_sys.list_installed_refs_for_update(None)
+    except GLib.Error as e:
+        print("Could not get updated flatpak refs")
+        return []
+
+    for ref in updates:
+        pkg_hash = make_pkg_hash(ref)
+
+        try:
+            updated.append(cache[pkg_hash])
+        except KeyError:
+            pass
+
+    return updated
+
+def find_pkginfo(cache, string):
+    for key in cache.get_subset_of_type("f").keys():
+        candidate = cache[key]
+
+        if string == candidate.name:
+            return candidate
+
+    return None
+
+def pkginfo_is_installed(pkginfo):
+    fp_sys = get_fp_sys()
+
+    try:
+        iref = fp_sys.get_installed_ref(pkginfo.kind,
+                                        pkginfo.name,
+                                        pkginfo.arch,
+                                        pkginfo.branch,
+                                        None)
+
+        if iref:
+            return True
+    except GLib.Error:
+        pass
+
+    return False
+
+def list_remotes():
+    fp_sys = get_fp_sys()
+
+    remotes = []
+
+    try:
+        for remote in fp_sys.list_remotes():
+            name = remote.get_name()
+            title = remote.get_title()
+
+            if title == None:
+                title = name.capitalize()
+
+            remotes.append((name, title))
+    except GLib.Error as e:
+        print("Could not fetch remote list", e.message)
+        remotes = []
+
+    return remotes
+
+def get_pkginfo_from_file(cache, uri, callback):
+    thread = threading.Thread(target=_pkginfo_from_file_thread, args=(cache, uri, callback))
+    thread.start()
+
+def _pkginfo_from_file_thread(cache, uri, callback):
+    fp_sys = get_fp_sys()
+
+    from urllib.parse import urlparse
+
+    if uri == None:
+        print("No valid uri provided")
+        return None
+
+    path = urlparse(uri).path
+
+    ref = None
+    pkginfo = None
+
+    with open(path) as f:
+        contents = f.read()
+
+        b = contents.encode("utf-8")
+        gb = GLib.Bytes(b)
+
+        try:
+            ref = fp_sys.install_ref_file(gb, None)
+
+            if ref:
+                remote_name = ref.get_remote_name()
+                remote = fp_sys.get_remote_by_name(remote_name, None)
+                _process_remote(None, fp_sys, remote, Flatpak.get_default_arch(), force_noenumerate=True)
+
+                pkginfo = _add_package_to_cache(cache, ref, remote.get_url(), False)
+
+                global _as_pools
+
+                if remote_name not in _as_pools.keys():
+                    _load_appstream_pool(_as_pools, remote)
+
+        except GLib.Error as e:
+            if e.code == Flatpak.Error.ALREADY_INSTALLED:
+                try:
+                    kf = GLib.KeyFile()
+                    if kf.load_from_file(path, GLib.KeyFileFlags.NONE):
+                        name = kf.get_string("Flatpak Ref", "Name")
+                        if name:
+                            pkginfo = find_pkginfo(cache, name)
+                except GLib.Error:
+                    print("Flatpak package already installed, but an error occurred finding it")
+            else:
+                print("Could not read .flatpakref file: %s" % e.message)
+
+    GLib.idle_add(callback, pkginfo, priority=GLib.PRIORITY_DEFAULT)
+
+def execute_transaction(task):
+    if len(task.to_install + task.to_remove + task.to_update) > 1:
+        dia = ChangesConfirmDialog(None, task)
+        res = dia.run()
+        dia.hide()
+        if res != Gtk.ResponseType.OK:
+            GObject.idle_add(task.finished_cleanup_cb, task)
+            return
+
+    if task.client_progress_cb != None:
+        task.has_window = True
+    else:
+        progress_window = FlatpakProgressWindow(task)
+        progress_window.present()
+
+    thread = threading.Thread(target=_execute_transaction_thread, args=(task,))
+    thread.start()
+
+def _execute_transaction_thread(task):
+    GLib.idle_add(task.client_progress_cb, task.pkginfo, 0, True, priority=GLib.PRIORITY_DEFAULT)
+
+    fp_sys = get_fp_sys()
+
+    task.transaction = MetaTransaction(fp_sys, task)
+
+class MetaTransaction():
+    def __init__(self, fp_sys, task):
+        self.fp_sys = fp_sys
+        self.task = task
+        pkginfo = self.pkginfo = task.pkginfo
+
+        task.to_install.reverse()
+
+        self.item_count = len(task.to_install + task.to_remove + task.to_update)
+        self.current_count = 0
+
+        try:
+            for str_ref in task.to_install:
+                ref = Flatpak.Ref.parse(str_ref)
+
+                task.progress_state = task.PROGRESS_STATE_INSTALLING
+                task.current_package_name = ref.get_name()
+
+                print("installing: %s" % str_ref)
+                self.fp_sys.install(pkginfo.remote,
+                                    ref.get_kind(),
+                                    ref.get_name(),
+                                    ref.get_arch(),
+                                    ref.get_branch(),
+                                    self.on_flatpak_progress,
+                                    None,
+                                    task.cancellable)
+
+                self.current_count += 1
+
+            for str_ref in task.to_remove:
+                ref = Flatpak.Ref.parse(str_ref)
+
+                task.progress_state = task.PROGRESS_STATE_REMOVING
+                task.current_package_name = ref.get_name()
+
+                print("removing: %s" % str_ref)
+                self.fp_sys.uninstall(ref.get_kind(),
+                                      ref.get_name(),
+                                      ref.get_arch(),
+                                      ref.get_branch(),
+                                      self.on_flatpak_progress,
+                                      None,
+                                      task.cancellable)
+
+                self.current_count += 1
+
+            for str_ref in task.to_update:
+                ref = Flatpak.Ref.parse(str_ref)
+
+                task.progress_state = task.PROGRESS_STATE_UPDATING
+                task.current_package_name = ref.get_name()
+
+                print("updating: %s" % str_ref)
+                self.fp_sys.update(Flatpak.UpdateFlags.NONE,
+                                   pkginfo.remote,
+                                   ref.get_kind(),
+                                   ref.get_name(),
+                                   ref.get_arch(),
+                                   ref.get_branch(),
+                                   self.on_flatpak_progress,
+                                   None,
+                                   task.cancellable)
+
+                self.current_count += 1
+        except GLib.Error as e:
+            if e.code != Gio.IOErrorEnum.CANCELLED:
+                task.progress_state = task.PROGRESS_STATE_FAILED
+                task.current_package_name = None
+                self.on_flatpak_error(e.message)
+                return
+
+        task.progress_state = task.PROGRESS_STATE_FINISHED
+        task.current_package_name = None
+        self.on_flatpak_finished()
+
+    def on_flatpak_progress(self, status, progress, estimating, data=None):
+        # Simple for now, each package gets an equal slice, and package progress is a percentage of that slice
+
+        package_chunk_size = 1.0 / self.item_count
+        partial_chunk = (progress / 100.0) * package_chunk_size
+
+        actual_progress = math.floor(((self.current_count * package_chunk_size) + partial_chunk) * 100.0)
+
+        GLib.idle_add(self.task.client_progress_cb, self.task.pkginfo, actual_progress, estimating, priority=GLib.PRIORITY_DEFAULT)
+
+    def on_flatpak_error(self, error_details):
+        self.task.error_message = error_details
+
+        # Show an error popup only if we're in mintinstall, otherwise a flatpak
+        # progress window will show the error details
+        if self.task.has_window:
+            dialogs.show_flatpak_error(error_details)
+
+        GLib.idle_add(self.task.error_cleanup_cb, self.task)
+
+    def on_flatpak_finished(self):
+        GLib.idle_add(self.task.finished_cleanup_cb, self.task)
+
+

--- a/usr/lib/linuxmint/mintinstall/installer/cache.py
+++ b/usr/lib/linuxmint/mintinstall/installer/cache.py
@@ -1,36 +1,23 @@
-import sys
-if sys.version_info.major < 3:
-    raise "python3 required"
-
-import gi
-gi.require_version('AppStream', '1.0')
-gi.require_version('Flatpak', '1.0')
-from gi.repository import GLib, GObject
-
-import signal
 import time
 import os
 from pathlib import Path
 import pickle
 import threading
 
+import gi
+gi.require_version('AppStream', '1.0')
+gi.require_version('Flatpak', '1.0')
+from gi.repository import GLib, GObject
+
 from installer import _apt
 from installer import _flatpak
 from installer.pkgInfo import PkgInfo
+from misc import print_timing
 
 SYS_CACHE_PATH = "/var/cache/mintinstall/pkginfo.cache"
 USER_CACHE_PATH = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "pkginfo.cache")
 
 MAX_AGE = 7 * (60 * 60 * 24) # days
-
-def print_timing(func):
-    def wrapper(*arg):
-        t1 = time.time()
-        res = func(*arg)
-        t2 = time.time()
-        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
-        return res
-    return wrapper
 
 class CacheLoadingException(Exception):
     '''Thrown when there was an issue loading the pickled package set'''
@@ -87,7 +74,7 @@ class PkgCache(object):
 
     def __contains__(self, pkg_hash):
         with self._item_lock:
-            return (pkg_hash in self._items)
+            return pkg_hash in self._items
 
     def __len__(self):
         with self._item_lock:
@@ -97,7 +84,7 @@ class PkgCache(object):
         with self._item_lock:
             for pkg_hash in self._items:
                 yield self[pkg_hash]
-            raise StopIteration
+            return
 
     def _generate_cache(self):
         cache = {}
@@ -113,7 +100,7 @@ class PkgCache(object):
             sys_mtime = os.path.getmtime(SYS_CACHE_PATH)
 
             if (time.time() - MAX_AGE) > sys_mtime:
-                print("system pkgcache too old, skipping")
+                print("MintInstall: System pkgcache too old, skipping")
                 sys_mtime = 0
         except OSError:
             sys_mtime = 0
@@ -122,7 +109,7 @@ class PkgCache(object):
             user_mtime = os.path.getmtime(USER_CACHE_PATH)
 
             if (time.time() - MAX_AGE) > user_mtime:
-                print("user pkgcache too old, skipping")
+                print("MintInstall: User pkgcache too old, skipping")
                 user_mtime = 0
         except OSError:
             user_mtime = 0
@@ -136,10 +123,10 @@ class PkgCache(object):
         # Select the most recent
         if sys_mtime > user_mtime:
             most_recent = SYS_CACHE_PATH
-            print("system pkgcache is most recent, using it.")
+            print("MintInstall: System pkgcache is most recent, using it.")
         else:
             most_recent = USER_CACHE_PATH
-            print("user pkgcache is most recent, using it.")
+            print("MintInstall: User pkgcache is most recent, using it.")
 
         return Path(most_recent)
 
@@ -156,7 +143,7 @@ class PkgCache(object):
 
         path = self._get_best_load_path()
 
-        if path == None:
+        if path is None:
             raise CacheLoadingException
 
         try:
@@ -165,7 +152,7 @@ class PkgCache(object):
                 cache = pickle_obj.pkginfo_cache
                 sections = pickle_obj.section_lists
         except Exception as e:
-            print("Error loading pkginfo cache:", e)
+            print("MintInstall: Error loading pkginfo cache:", e)
             cache = None
 
         if cache == None:
@@ -204,10 +191,10 @@ class PkgCache(object):
             with path.open(mode='wb') as f:
                 pickle.dump(to_be_pickled, f)
         except Exception as e:
-            print("Could not save cache:", str(e))
+            print("MintInstall: Could not save cache:", str(e))
 
     def _new_cache_common(self):
-        print("Generating new pkgcache")
+        print("MintInstall: Generating new pkgcache")
         cache, sections = self._generate_cache()
 
         if len(cache) > 0:
@@ -230,11 +217,11 @@ class PkgCache(object):
 
     def get_subset_of_type(self, pkg_type):
         with self._item_lock:
-            return { k: v for k, v in self._items.items() if k.startswith(pkg_type) }
+            return {k: v for k, v in self._items.items() if k.startswith(pkg_type)}
 
     def force_new_cache_async(self, idle_callback=None):
         thread = threading.Thread(target=self._generate_cache_thread,
-                                  kwargs={ "callback" : idle_callback })
+                                  kwargs={"callback" : idle_callback})
         thread.start()
 
     def force_new_cache(self):
@@ -254,21 +241,3 @@ class PkgCache(object):
                 return pkginfo
 
         return None
-
-# Debugging - you can run cache.py on its own, and inspect the PkgCache (i)
-
-if __name__ == "__main__":
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    i = PkgCache()
-
-    import readline
-    import code
-    variables = globals().copy()
-    variables.update(locals())
-    shell = code.InteractiveConsole(variables)
-    shell.interact()
-
-    ml = GLib.MainLoop.new(None, True)
-    ml.run()
-

--- a/usr/lib/linuxmint/mintinstall/installer/cache.py
+++ b/usr/lib/linuxmint/mintinstall/installer/cache.py
@@ -1,0 +1,274 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import gi
+gi.require_version('AppStream', '1.0')
+gi.require_version('Flatpak', '1.0')
+from gi.repository import GLib, GObject
+
+import signal
+import time
+import os
+from pathlib import Path
+import pickle
+import threading
+
+from installer import _apt
+from installer import _flatpak
+from installer.pkgInfo import PkgInfo
+
+SYS_CACHE_PATH = "/var/cache/mintinstall/pkginfo.cache"
+USER_CACHE_PATH = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "pkginfo.cache")
+
+MAX_AGE = 7 * (60 * 60 * 24) # days
+
+def print_timing(func):
+    def wrapper(*arg):
+        t1 = time.time()
+        res = func(*arg)
+        t2 = time.time()
+        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
+        return res
+    return wrapper
+
+class CacheLoadingException(Exception):
+    '''Thrown when there was an issue loading the pickled package set'''
+
+class PickleObject(object):
+    def __init__(self, pkginfo_cache, section_lists):
+        super(PickleObject, self).__init__()
+
+        self.pkginfo_cache = pkginfo_cache
+        self.section_lists = section_lists
+
+class PkgCache(object):
+    STATUS_EMPTY = 0
+    STATUS_OK = 1
+
+    @print_timing
+    def __init__(self):
+        super(PkgCache, self).__init__()
+
+        self.status = self.STATUS_EMPTY
+
+        self._items = {}
+        self._item_lock = threading.Lock()
+
+        try:
+            cache, sections = self._load_cache()
+        except CacheLoadingException:
+            cache = {}
+            sections = {}
+
+        if len(cache) > 0:
+            self.status = self.STATUS_OK
+        else:
+            self.status = self.STATUS_EMPTY
+
+        self._items = cache
+        self.sections = sections
+
+    def keys(self):
+        with self._item_lock:
+            return self._items.keys()
+
+    def values(self):
+        with self._item_lock:
+            return self._items.values()
+
+    def __getitem__(self, key):
+        with self._item_lock:
+            return self._items[key]
+
+    def __setitem__(self, key, value):
+        with self._item_lock:
+            self._items[key] = value
+
+    def __contains__(self, pkg_hash):
+        with self._item_lock:
+            return (pkg_hash in self._items)
+
+    def __len__(self):
+        with self._item_lock:
+            return len(self._items)
+
+    def __iter__(self):
+        with self._item_lock:
+            for pkg_hash in self._items:
+                yield self[pkg_hash]
+            raise StopIteration
+
+    def _generate_cache(self):
+        cache = {}
+        sections = {}
+
+        cache = _flatpak.process_full_flatpak_installation(cache)
+        cache, sections = _apt.process_full_apt_cache(cache)
+
+        return cache, sections
+
+    def _get_best_load_path(self):
+        try:
+            sys_mtime = os.path.getmtime(SYS_CACHE_PATH)
+
+            if (time.time() - MAX_AGE) > sys_mtime:
+                print("system pkgcache too old, skipping")
+                sys_mtime = 0
+        except OSError:
+            sys_mtime = 0
+
+        try:
+            user_mtime = os.path.getmtime(USER_CACHE_PATH)
+
+            if (time.time() - MAX_AGE) > user_mtime:
+                print("user pkgcache too old, skipping")
+                user_mtime = 0
+        except OSError:
+            user_mtime = 0
+
+        # If neither exist, return None, and a new cache will be generated
+        if sys_mtime == 0 and user_mtime == 0:
+            return None
+
+        most_recent = None
+
+        # Select the most recent
+        if sys_mtime > user_mtime:
+            most_recent = SYS_CACHE_PATH
+            print("system pkgcache is most recent, using it.")
+        else:
+            most_recent = USER_CACHE_PATH
+            print("user pkgcache is most recent, using it.")
+
+        return Path(most_recent)
+
+    @print_timing
+    def _load_cache(self):
+        """
+        The cache pickle file can be in either a system or user location,
+        depending on how the cache was generated.  If it exists in both places, take the
+        most recent one.  If it's more than MAX_AGE, generate a new one anyhow.
+        """
+
+        cache = None
+        sections = None
+
+        path = self._get_best_load_path()
+
+        if path == None:
+            raise CacheLoadingException
+
+        try:
+            with path.open(mode='rb') as f:
+                pickle_obj = pickle.load(f)
+                cache = pickle_obj.pkginfo_cache
+                sections = pickle_obj.section_lists
+        except Exception as e:
+            print("Error loading pkginfo cache:", e)
+            cache = None
+
+        if cache == None:
+            raise CacheLoadingException
+
+        return cache, sections
+
+    def _get_best_save_path(self):
+        best_path = None
+
+        # Prefer the system location, as all users can access it
+        try:
+            path = Path(SYS_CACHE_PATH)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+        except PermissionError:
+            try:
+                path = Path(USER_CACHE_PATH)
+                path.parent.mkdir(parents=True, exist_ok=True)
+            except Exception:
+                path = None
+        finally:
+            best_path = path
+
+        return best_path
+
+    def _save_cache(self, to_be_pickled):
+        path = self._get_best_save_path()
+
+        # Depickling later may fail if we _load_cache from a different context or module.
+        # This explicitly stores the module name PkgInfo is defined in, within the pickle
+        # file.
+        PkgInfo.__module__ = "installer.pkgInfo"
+
+        try:
+            with path.open(mode='wb') as f:
+                pickle.dump(to_be_pickled, f)
+        except Exception as e:
+            print("Could not save cache:", str(e))
+
+    def _new_cache_common(self):
+        print("Generating new pkgcache")
+        cache, sections = self._generate_cache()
+
+        if len(cache) > 0:
+            self._save_cache(PickleObject(cache, sections))
+
+        with self._item_lock:
+            self._items = cache
+            self.sections = sections
+
+        if len(cache) == 0:
+            self.status = self.STATUS_EMPTY
+        else:
+            self.status = self.STATUS_OK
+
+    def _generate_cache_thread(self, callback=None):
+        self._new_cache_common()
+
+        if callback != None:
+            GObject.idle_add(callback)
+
+    def get_subset_of_type(self, pkg_type):
+        with self._item_lock:
+            return { k: v for k, v in self._items.items() if k.startswith(pkg_type) }
+
+    def force_new_cache_async(self, idle_callback=None):
+        thread = threading.Thread(target=self._generate_cache_thread,
+                                  kwargs={ "callback" : idle_callback })
+        thread.start()
+
+    def force_new_cache(self):
+        self._new_cache_common()
+
+    def find_pkginfo(self, string, pkg_type=None):
+        if pkg_type in (None, "a"):
+            pkginfo = _apt.find_pkginfo(self, string)
+
+            if pkginfo != None:
+                return pkginfo
+
+        if pkg_type in (None, "f"):
+            pkginfo = _flatpak.find_pkginfo(self, string)
+
+            if pkginfo != None:
+                return pkginfo
+
+        return None
+
+# Debugging - you can run cache.py on its own, and inspect the PkgCache (i)
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    i = PkgCache()
+
+    import readline
+    import code
+    variables = globals().copy()
+    variables.update(locals())
+    shell = code.InteractiveConsole(variables)
+    shell.interact()
+
+    ml = GLib.MainLoop.new(None, True)
+    ml.run()
+

--- a/usr/lib/linuxmint/mintinstall/installer/dialogs.py
+++ b/usr/lib/linuxmint/mintinstall/installer/dialogs.py
@@ -1,0 +1,326 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import gi
+gi.require_version('XApp', '1.0')
+from gi.repository import GLib, Gtk, GObject, Gdk, XApp, Flatpak
+
+import gettext
+_ = gettext.gettext
+
+
+from aptdaemon.gtk3widgets import AptConfirmDialog
+
+######################### Subclass Apt's dialog to keep consistency
+
+class ChangesConfirmDialog(AptConfirmDialog):
+
+    """Dialog to confirm the changes that would be required by a
+    transaction.
+    """
+
+    def __init__(self, transaction, task):
+        super(ChangesConfirmDialog, self).__init__(transaction, cache=None, parent=task.parent_window)
+
+        self.task = task
+
+    def _show_changes(self):
+        """Show a message and the dependencies in the dialog."""
+        self.treestore.clear()
+
+        # Run parent method for apt
+        if self.task.pkginfo.pkg_hash.startswith("a"):
+            super(ChangesConfirmDialog, self)._show_changes()
+        else:
+            # flatpak
+            self.set_title(_("Flatpaks"))
+
+            if len(self.task.to_install) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Install")])
+
+                for str_ref in self.task.to_install:
+                    if self.task.pkginfo.refid == str_ref:
+                        continue
+
+                    self.treestore.append(piter, [Flatpak.Ref.parse(str_ref).get_name()])
+
+            if len(self.task.to_remove) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Remove")])
+
+                for str_ref in self.task.to_remove:
+                    if self.task.pkginfo.refid == str_ref:
+                        continue
+
+                    self.treestore.append(piter, [Flatpak.Ref.parse(str_ref).get_name()])
+
+            if len(self.task.to_update) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Upgrade")])
+
+                for str_ref in self.task.to_update:
+                    if self.task.pkginfo.refid == str_ref:
+                        continue
+
+                    self.treestore.append(piter, [Flatpak.Ref.parse(str_ref).get_name()])
+
+            msg = _("Please take a look at the list of changes below.")
+
+            if len(self.treestore) == 1:
+                filtered_store = self.treestore.filter_new(
+                    Gtk.TreePath.new_first())
+                self.treeview.expand_all()
+                self.treeview.set_model(filtered_store)
+                self.treeview.set_show_expanders(False)
+
+                if len(self.task.to_install) > 0:
+                    title = _("Additional software has to be installed")
+                elif len(self.task.to_remove) > 0:
+                    title = _("Additional software has to be removed")
+                elif len(self.task.to_update) > 0:
+                    title = _("Additional software has to be upgraded")
+
+                if len(filtered_store) < 6:
+                    self.set_resizable(False)
+                    self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC,
+                                             Gtk.PolicyType.NEVER)
+                else:
+                    self.treeview.set_size_request(350, 200)
+            else:
+                title = _("Additional changes are required")
+                self.treeview.set_size_request(350, 200)
+                self.treeview.collapse_all()
+
+            if self.task.download_size > 0:
+                msg += "\n"
+                msg += (_("%s will be downloaded in total.") %
+                        GLib.format_size(self.task.download_size))
+            if self.task.freed_size > 0:
+                msg += "\n"
+                msg += (_("%s of disk space will be freed.") %
+                        GLib.format_size(self.task.freed_size))
+            elif self.task.install_size > 0:
+                msg += "\n"
+                msg += (_("%s more disk space will be used.") %
+                        GLib.format_size(self.task.install_size))
+            self.label.set_markup("<b><big>%s</big></b>\n\n%s" % (title, msg))
+
+    def render_package_desc(self, column, cell, model, iter, data):
+        value = model.get_value(iter, 0)
+
+        cell.set_property("markup", value)
+
+
+class FlatpakProgressWindow(Gtk.Dialog):
+    """
+    Progress dialog for standalone flatpak installs, removals, updates.
+    Intended to be used when not working as part of a parent app (like mintinstall)
+    """
+
+    def __init__(self, task, parent=None):
+        Gtk.Dialog.__init__(self, parent=parent)
+
+        self.task = task
+        self.finished = False
+
+        # Progress goes directly to this window
+        task.client_progress_cb = self.window_client_progress_cb
+
+        # finished callbacks route thru the installer
+        # but we want to see them in this window also.
+        self.final_finished_cb = task.client_finished_cb
+        task.client_finished_cb = self.window_client_finished_cb
+
+        self.pulse_timer = 0
+        self.active_task_state = task.progress_state
+
+        self.real_progress_text = None
+        self.num_dots = 0
+
+        # Setup the dialog
+        self.set_border_width(6)
+        self.set_resizable(False)
+        self.get_content_area().set_spacing(6)
+        # Setup the cancel button
+        self.button = Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
+        self.button.set_use_stock(True)
+        self.get_action_area().pack_start(self.button, False, False, 0)
+        self.button.connect("clicked", self.on_button_clicked)
+        self.button.show()
+
+        # labels and progressbar
+        hbox = Gtk.HBox()
+        hbox.set_spacing(12)
+        hbox.set_border_width(6)
+        vbox = Gtk.VBox()
+        vbox.set_spacing(12)
+
+        self.phase_label = Gtk.Label()
+        vbox.pack_start(self.phase_label, False, False, 0)
+        self.phase_label.set_halign(Gtk.Align.START)
+
+        vbox_progress = Gtk.VBox()
+        vbox_progress.set_spacing(6)
+        self.progress = Gtk.ProgressBar()
+        vbox_progress.pack_start(self.progress, False, True, 0)
+
+        self.progress_label = Gtk.Label()
+        vbox_progress.pack_start(self.progress_label, False, False, 0)
+        self.progress_label.set_halign(Gtk.Align.START)
+        self.progress_label.set_line_wrap(True)
+        self.progress_label.set_max_width_chars(60)
+
+        vbox.pack_start(vbox_progress, False, True, 0)
+        hbox.pack_start(vbox, True, True, 0)
+
+        self.get_content_area().pack_start(hbox, True, True, 0)
+
+        self.set_title(_("Flatpak Progress"))
+        XApp.set_window_icon_name(self, "system-software-installer")
+
+        hbox.show_all()
+        self.realize()
+
+        self.progress.set_size_request(350, -1)
+        functions = Gdk.WMFunction.MOVE | Gdk.WMFunction.RESIZE
+        try:
+            self.get_window().set_functions(functions)
+        except TypeError:
+            # workaround for older and broken GTK typelibs
+            self.get_window().set_functions(Gdk.WMFunction(functions))
+
+        self.update_labels()
+
+        # catch ESC and behave as if cancel was clicked
+        self.connect("delete-event", self._on_dialog_delete_event)
+
+    def set_progress_text(self, text):
+        if text != self.real_progress_text:
+            self.real_progress_text = text
+            self.progress_label.set_text(text)
+        else:
+            self.tick()
+
+    def tick(self):
+        if self.num_dots < 5:
+            self.num_dots += 1
+        else:
+            self.num_dots = 0
+
+        new_string = self.real_progress_text
+
+        i = 0
+
+        while i < self.num_dots:
+            new_string += "."
+            i += 1
+
+        self.progress_label.set_text(new_string)
+
+    def update_labels(self):
+        phase_label = ""
+
+        if self.task.cancellable.is_cancelled():
+            phase_label = _("Cancelled")
+            self.set_progress_text(_("The operation was cancelled before it could complete."))
+        elif self.task.progress_state == self.task.PROGRESS_STATE_INIT:
+            phase_label = _("Initializing")
+            self.set_progress_text("")
+        elif self.task.progress_state == self.task.PROGRESS_STATE_INSTALLING:
+            phase_label = _("Installing flatpaks")
+            self.set_progress_text(_("Installing: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_REMOVING:
+            phase_label = _("Removing flatpaks")
+            self.set_progress_text(_("Removing: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_UPDATING:
+            phase_label = _("Updating flatpaks")
+            self.set_progress_text(_("Updating: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_FINISHED:
+            phase_label = _("Finished")
+            self.set_progress_text(_("Operation completed successfully"))
+        elif self.task.progress_state == self.task.PROGRESS_STATE_FAILED:
+            phase_label = _("Failed")
+            self.set_progress_text(_("An error occurred:\n\n%s") % self.task.error_message)
+
+        self.phase_label.set_markup("<big><b>%s</b></big>" % phase_label)
+        self.set_title(phase_label)
+
+    def start_progress_pulse(self):
+        if self.pulse_timer > 0:
+            return
+
+        self.progress.pulse()
+        self.pulse_timer = GObject.timeout_add(1050, self.progress_pulse_tick)
+
+    def progress_pulse_tick(self):
+        self.progress.pulse()
+
+        return GLib.SOURCE_CONTINUE
+
+    def stop_progress_pulse(self):
+        if self.pulse_timer > 0:
+            GObject.source_remove(self.pulse_timer)
+            self.pulse_timer = 0
+
+    def _on_dialog_delete_event(self, dialog, event):
+        self.button.clicked()
+        return True
+
+    def window_client_progress_cb(self, pkginfo, progress, estimating):
+        if estimating:
+            self.start_progress_pulse()
+        else:
+            self.stop_progress_pulse()
+
+            self.progress.set_fraction(progress / 100.0)
+            XApp.set_window_progress(self, progress)
+            self.tick()
+
+        self.update_labels()
+
+    def window_client_finished_cb(self, pkginfo, error_message):
+        self.finished = True
+
+        XApp.set_window_progress(self, 0)
+        self.stop_progress_pulse()
+
+        self.progress.set_fraction(1.0)
+
+        self.update_labels()
+
+        if error_message:
+            self.set_urgency_hint(True)
+            self.button.set_label(Gtk.STOCK_CLOSE)
+        else:
+            self.destroy()
+            self.final_finished_cb(self.task.pkginfo, error_message)
+
+    def on_button_clicked(self, button):
+        if not self.finished:
+            self.task.cancellable.cancel()
+        else:
+            self.destroy()
+            self.final_finished_cb(self.task.pkginfo, self.task.error_message)
+
+def show_flatpak_error(message):
+    GObject.idle_add(_show_flatpak_error_mainloop, message, priority=GLib.PRIORITY_DEFAULT)
+
+def _show_flatpak_error_mainloop(message):
+
+    dialog = Gtk.MessageDialog(None,
+                               Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                               Gtk.MessageType.ERROR,
+                               Gtk.ButtonsType.OK,
+                               "")
+
+    text = _("An error occurred")
+    dialog.set_markup("<big><b>%s</b></big>" % text)
+    message_label = Gtk.Label(message)
+    dialog.get_message_area().pack_start(message_label, False, False, 6)
+    message_label.set_line_wrap(True)
+    message_label.set_max_width_chars(60)
+    message_label.show()
+
+    dialog.run()
+    dialog.hide()
+
+    return False

--- a/usr/lib/linuxmint/mintinstall/installer/dialogs.py
+++ b/usr/lib/linuxmint/mintinstall/installer/dialogs.py
@@ -1,14 +1,13 @@
-import sys
-if sys.version_info.major < 3:
-    raise "python3 required"
-
 import gi
 gi.require_version('XApp', '1.0')
 from gi.repository import GLib, Gtk, GObject, Gdk, XApp, Flatpak
 
 import gettext
+APP = 'mintinstall'
+LOCALE_DIR = "/usr/share/linuxmint/locale"
+gettext.bindtextdomain(APP, LOCALE_DIR)
+gettext.textdomain(APP)
 _ = gettext.gettext
-
 
 from aptdaemon.gtk3widgets import AptConfirmDialog
 

--- a/usr/lib/linuxmint/mintinstall/installer/installer.py
+++ b/usr/lib/linuxmint/mintinstall/installer/installer.py
@@ -1,0 +1,449 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+import threading
+import signal
+import time
+
+import gi
+gi.require_version('AppStream', '1.0')
+gi.require_version('Flatpak', '1.0')
+from gi.repository import GLib, GObject, Gio
+
+from installer import cache, _flatpak, _apt
+
+PKG_TYPE_NONE = None
+PKG_TYPE_APT = "a"
+PKG_TYPE_FLATPAK = "f"
+
+# the action that initiated the task
+INSTALL_TASK = "install"
+UNINSTALL_TASK = "remove"
+UPDATE_TASK = "update"
+
+def print_timing(func):
+    def wrapper(*arg):
+        t1 = time.time()
+        res = func(*arg)
+        t2 = time.time()
+        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
+        return res
+    return wrapper
+
+class InstallerTask:
+    # Set after a package selection, reflects whether task can proceed or not
+    STATUS_NONE = "none"
+    STATUS_OK = "ok"
+    STATUS_BROKEN = "broken"
+    STATUS_FORBIDDEN = "forbidden"
+
+    # Used by standalone progress window to update labels appropriately
+    PROGRESS_STATE_INIT = "init"
+    PROGRESS_STATE_INSTALLING = "installing"
+    PROGRESS_STATE_UPDATING = "updating"
+    PROGRESS_STATE_REMOVING = "removing"
+    PROGRESS_STATE_FINISHED = "finished"
+    PROGRESS_STATE_FAILED = "failed"
+
+    def __init__(self, pkginfo, installer, info_ready_callback):
+        self.type = INSTALL_TASK
+
+        self.parent_window = None
+
+        # pkginfo will be None for an update task
+        self.pkginfo = pkginfo
+
+        self.name = None
+
+        # Set by .select_pkginfo(), the re-entry point after a task is fully calculated,
+        # and the UI should be updated with detailed info about the pending operation (disk use, etc..)
+        self.info_ready_callback = info_ready_callback
+        # To be checked by the info_ready_callback, to allow the UI to reflect the ability to proceed with a task, or
+        # report that something is not right.
+        self.info_ready_status = self.STATUS_NONE
+
+        # Set by the backend, the function to call to actually perform the task (will be none on STATUS_BROKEN or _FORBIDDEN)
+        self.execute = None
+
+        # Passed to _flatpak operations to respond to the Cancel button in the standalone progress window.
+        # eventually it may be used elsewhere.
+        self.cancellable = Gio.Cancellable()
+
+        # Callbacks that will be used at various points during a task being operated on.  The .client_* callbacks are arguments
+        # of Installer.execute_task().  The client_finished_cb is required.  If the progress callback is missing, a standalone
+        # progress window will be provided.
+        self.client_progress_cb = None
+        self.client_finished_cb = None
+
+        # These are internally used - called as the 'real' error and finished callback, to do some cleanup
+        # like removing the task and reloading the apt cache before finally calling task.client_finished_cb
+        self.error_cleanup_cb = None
+        self.finished_cleanup_cb = None
+
+        self.has_window = False
+        # Updated throughout a flatpak operation - for now it's used for updating the standalone flatpak progress window
+        self.progress_state = self.PROGRESS_STATE_INIT
+        # Same - allows the flatpak window to update the current package being installed/removed
+        self.current_package_name = None
+        # The error message displayed in a popup if a flatpak operation fails.
+        self.error_message = None
+
+        # apt only, stores the AptTransaction
+        self.transaction = None
+
+        # The command that can be used to launch the current target package, if it's installed
+        self.exec_string = None
+
+        # List of additional packages to install, remove or update, based on the selected pkginfo.
+        # Always lists of strings, but depending on the backend, they will consist of package names (apt)
+        # or stringified flatpak refs (the result of ref.format_ref())
+        self.to_install = []
+        self.to_remove = []
+        self.to_update = []
+
+        # Size info for display, calculated by the backend during .select_pkginfo()
+        self.download_size = 0
+        self.install_size = 0
+        self.freed_size = 0
+
+        # Static info filled in for display
+        if pkginfo:
+            self.name = pkginfo.name
+
+            if pkginfo.pkg_hash.startswith("a"):
+                self.arch = ""
+                self.branch = ""
+                self.remote = ""
+            else:
+                self.arch = pkginfo.arch
+                self.remote = pkginfo.remote
+                self.branch = pkginfo.branch
+
+            self.version = installer.get_version(pkginfo)
+
+class Installer:
+    def __init__(self):
+        self.tasks = {}
+
+        self.inited = False
+
+        self.cache = {}
+        self.backend_table = {}
+        self._init_cb = None
+
+        self.startup_timer = time.time()
+
+    def init_sync(self):
+        """
+        Loads the cache asynchronously.  If there is no cache (or it's too old,) it causes
+        one to be generated and saved.  The ready_callback is called on idle once this is finished.
+        """
+        self.cache = cache.PkgCache()
+
+        if self.cache.status == self.cache.STATUS_OK:
+            self.inited = True
+
+            GObject.idle_add(self.initialize_appstream)
+
+            return True
+        else:
+            return False
+
+    def init(self, ready_callback=None):
+        """
+        Loads the cache asynchronously.  If there is no cache (or it's too old,) it causes
+        one to be generated and saved.  The ready_callback is called on idle once this is finished.
+        """
+        self.cache = cache.PkgCache()
+
+        self._init_cb = ready_callback
+
+        if self.cache.status == self.cache.STATUS_OK:
+            self.inited = True
+
+            GObject.idle_add(self._idle_cache_load_done)
+        else:
+            self.cache.force_new_cache_async(self._idle_cache_load_done)
+
+        return self
+
+    def _idle_cache_load_done(self):
+        self.inited = True
+
+        GObject.idle_add(self.initialize_appstream)
+
+        print('installer startup full took %0.3f ms' % ((time.time() - self.startup_timer) * 1000.0))
+
+        if self._init_cb:
+            self._init_cb()
+
+    def select_pkginfo(self, pkginfo, ready_callback):
+        """
+        Initiates calculations for installing or removing a particular package (depending upon whether or not
+        the selected package is installed.  Creates an InstallerTask instance and populates it with info relevant
+        for display and for execution later.  When this is completed, ready_callback is called, with the newly-created
+        task as its argument.  Note:  At that point, this is the *only* reference to the task object.  It can be safely
+        discarded.  If the task is to be run, Installer.execute_task() is called, passing this task object, along with
+        callback functions.  The task object is then added to a queue (and is tracked in self.tasks from there on out.)
+        """
+        if pkginfo.pkg_hash in self.tasks.keys():
+            task = self.tasks[pkginfo.pkg_hash]
+
+            GObject.idle_add(task.info_ready_callback, task)
+            return
+
+        task = InstallerTask(pkginfo, self, ready_callback)
+
+        if self.pkginfo_is_installed(pkginfo):
+            # It's not installed, so assume we're installing
+            task.type = UNINSTALL_TASK
+        else:
+            task.type = INSTALL_TASK
+
+        if pkginfo.pkg_hash.startswith("a"):
+            _apt.select_packages(task)
+        else:
+            _flatpak.select_packages(task)
+
+    def prepare_flatpak_update(self, ready_callback):
+        """
+        Creates an InstallerTask populated with all flatpak packages that can be updated.  Note, unlike select_pkginfo,
+        there is no 'primary' package here.  Only disk utilization and download info, along with the list of ref strings
+        (in task.to_update) will be populated.
+        """
+        task = InstallerTask(None, self, ready_callback)
+
+        task.type = UPDATE_TASK
+
+        _flatpak.select_updates(task)
+
+    def list_updated_flatpak_pkginfos(self):
+        """
+        Returns a list of flatpak pkginfos that can be updated.  Unlike prepare_flatpak_update, this is for the convenience
+        of displaying information to the user.
+        """
+        return _flatpak.list_updated_pkginfos(self.cache)
+
+    def find_pkginfo(self, name, pkg_type=PKG_TYPE_NONE):
+        """
+        Attempts to find and return a PkgInfo object, given a package name.  If pkg_type is None, looks in first apt,
+        then flatpaks.
+        """
+        return self.cache.find_pkginfo(name, pkg_type)
+
+    def get_pkginfo_from_ref_file(self, uri, ready_callback):
+        """
+        Accepts a uri to a .flatpakref on a local path.  If the flatpak's remote has not been previously added to the system
+        installation, this also adds it and downloads Appstream info as well, before calling ready_callback with the created
+        (or existing) PkgInfo as an argument.
+        """
+        _flatpak.get_pkginfo_from_file(self.cache, uri, ready_callback)
+
+    def list_flatpak_remotes(self):
+        """
+        Returns a list of tuples of (remote name, remote title).  The remote_name can be used to match with PkgInfo.remote
+        and the title is for display.
+        """
+        return _flatpak.list_remotes()
+
+    def pkginfo_is_installed(self, pkginfo):
+        """
+        Returns whether or not a given package is currently installed.  This uses the AptCache or the FlatpakInstallation
+        to check.
+        """
+        if self.inited:
+            if pkginfo.pkg_hash.startswith("a"):
+                return _apt.pkginfo_is_installed(pkginfo)
+            elif pkginfo.pkg_hash.startswith("f"):
+                return _flatpak.pkginfo_is_installed(pkginfo)
+        else:
+            return False
+
+    @print_timing
+    def initialize_appstream(self):
+        """
+        Loads and caches the AppStream pools so they can be used to provide
+        display info for packages.
+        """
+        _flatpak.initialize_appstream()
+        # Is there any reason to use apt's appstream?
+
+    def _get_backend_component(self, pkginfo):
+        try:
+            backend_component = self.backend_table[pkginfo]
+
+            return backend_component
+        except KeyError:
+            if pkginfo.pkg_hash.startswith("a"):
+                backend_component = _apt.search_for_pkginfo_apt_pkg(pkginfo)
+            else:
+                backend_component = _flatpak.search_for_pkginfo_as_component(pkginfo)
+
+            self.backend_table[pkginfo] = backend_component
+
+            # It's possible at some point we'll refresh appstream at runtime, if so we'll
+            # want to clear cached data so it can be re-fetched anew.  For now there's no need.
+            # The only possible case is on-demand adding of a remote (from launching a .flatpakref
+            # file), and in this case, we won't have had anything cached for it to clear anyhow.
+
+            # pkginfo.clear_cached_info()
+
+            return backend_component
+
+    def get_display_name(self, pkginfo):
+        """
+        Returns the name of the package formatted for displaying
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_display_name(comp)
+
+    def get_summary(self, pkginfo, for_search=False):
+        """
+        Returns the summary of the package.  If for_search is True,
+        this is the raw, unformatted string in the case of apt.
+        """
+        if for_search and pkginfo.pkg_hash.startswith("a"):
+            try:
+                return _apt._apt_cache[pkginfo.name].candidate.summary
+            except Exception:
+                pass
+
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_summary(comp)
+
+    def get_description(self, pkginfo, for_search=False):
+        """
+        Returns the description of the package.  If for_search is True,
+        this is the raw, unformatted string in the case of apt.
+        """
+        if for_search and pkginfo.pkg_hash.startswith("a"):
+            try:
+                return _apt._apt_cache[pkginfo.name].candidate.description
+            except Exception:
+                pass
+
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_description(comp)
+
+    def get_icon(self, pkginfo):
+        """
+        Returns the icon name (or path) to display for the package
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_icon(comp)
+
+    def get_screenshots(self, pkginfo):
+        """
+        Returns a list of screenshot urls
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_screenshots(comp)
+
+    def get_version(self, pkginfo):
+        """
+        Returns the current version string, if available
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_version(comp)
+
+    def get_url(self, pkginfo):
+        """
+        Returns the home page url for a package.  If there is
+        no url for the package, in the case of flatpak, the remote's url
+        is displayed instead
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_url(comp)
+
+    def is_busy(self):
+        return len(self.tasks.keys()) > 0
+
+    def get_task_count(self):
+        return len(self.tasks.keys())
+
+    def get_active_pkginfos(self):
+        pkginfos = []
+
+        for pkg_hash in self.tasks.keys():
+            pkginfos.append(self.tasks[pkg_hash].pkginfo)
+
+        return pkginfos
+
+    def task_running(self, task):
+        """
+        Returns whether a given task is currently executing.
+        """
+        return task.pkginfo.pkg_hash in self.tasks.keys()
+
+    def execute_task(self, task, client_finished_cb, client_progress_cb=None):
+        """
+        Executes a given task.  The client_finished_cb is required always, to notify when the task completes.
+        The progress and error callbacks are optional.  If they're left out, a standalone progress window is created
+        to allow the user to see the task's progress (and cancel it if desired.)
+        """
+        self.tasks[task.pkginfo.pkg_hash] = task
+        print("Starting task for package %s, type '%s'" % (task.pkginfo.pkg_hash, task.type))
+
+        task.client_finished_cb = client_finished_cb
+        task.client_progress_cb = client_progress_cb
+
+        task.finished_cleanup_cb = self._task_finished
+        task.error_cleanup_cb = self._task_error
+
+        task.execute(task)
+
+    def _task_finished(self, task):
+        print("Done with task (success)", task.pkginfo.pkg_hash)
+        del self.tasks[task.pkginfo.pkg_hash]
+
+        self._post_task_update(task)
+
+    def _task_error(self, task):
+        print("Done with task (error)", task.pkginfo.pkg_hash)
+        del self.tasks[task.pkginfo.pkg_hash]
+
+        self._post_task_update(task)
+
+    def _post_task_update(self, task):
+        if task.pkginfo.pkg_hash.startswith("a"):
+            thread = threading.Thread(target=self._apt_post_task_update_thread, args=(task,))
+            thread.start()
+        else:
+            self._run_client_callback(task)
+
+    def _apt_post_task_update_thread(self, task):
+        _apt.sync_cache_installed_states()
+
+        # This needs to be called after reloading the apt cache, otherwise our installed
+        # apps don't update correctly
+        self._run_client_callback(task)
+
+    def _run_client_callback(self, task):
+        GObject.idle_add(task.client_finished_cb, task.pkginfo, task.error_message)
+
+def interact():
+    import readline
+    import code
+    variables = globals().copy()
+    variables.update(locals())
+    shell = code.InteractiveConsole(variables)
+    shell.interact()
+
+# Debugging - you can run installer.py on its own, and test things with the Installer (i)
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    i = Installer()
+    i.init(ready_callback=interact)
+
+    ml = GLib.MainLoop.new(None, True)
+    ml.run()

--- a/usr/lib/linuxmint/mintinstall/installer/pkgInfo.py
+++ b/usr/lib/linuxmint/mintinstall/installer/pkgInfo.py
@@ -1,0 +1,333 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+from gi.repository import AppStream
+
+def capitalize(string):
+    if string and len(string) > 1:
+        return (string[0].upper() + string[1:])
+    else:
+        return (string)
+
+class PkgInfo:
+    __slots__ = "pkg_hash", "name", "display_name", "summary", "description",    \
+                "icon", "screenshots", "url", "version", "categories", "refid",  \
+                "remote", "remote_url", "kind", "arch", "branch", "commit"
+
+    def __init__(self, pkg_hash):
+        # Saved stuff
+        self.pkg_hash = pkg_hash
+        self.name = None
+        # some flatpak-specific things
+        self.refid=""
+        self.remote = ""
+        self.kind = 0
+        self.arch = ""
+        self.branch = ""
+        self.commit = ""
+        self.remote_url = ""
+
+        # Display info fetched by methods always
+        self.display_name = None
+        self.summary = None
+        self.description = None
+        self.version = None
+        self.icon = None
+        self.screenshots = []
+        self.url = None
+
+        # Runtime categories
+        self.categories = []
+
+    def __getstate__(self):
+        return (                                 \
+        self.pkg_hash,       self.name,          \
+        self.remote,         self.remote_url,    \
+        self.kind,           self.arch,          \
+        self.branch,         self.commit,        \
+        self.refid                               \
+        )
+
+    def __setstate__(self, state):
+        self.pkg_hash,       self.name,          \
+        self.remote,         self.remote_url,    \
+        self.kind,           self.arch,          \
+        self.branch,         self.commit,        \
+        self.refid                               = state
+
+        self.categories = []
+        self.clear_cached_info()
+
+    def clear_cached_info(self):
+        self.display_name = None
+        self.summary = None
+        self.description = None
+        self.icon = None
+        self.screenshots = []
+        self.version = None
+        self.url = None
+
+class AptPkgInfo(PkgInfo):
+    def __init__(self, pkg_hash, apt_pkg):
+        super(AptPkgInfo, self).__init__(pkg_hash)
+        self.name = apt_pkg.name
+
+    def get_display_name(self, apt_pkg=None):
+        # fastest
+        if self.display_name:
+            return self.display_name
+
+        if apt_pkg:
+            self.display_name = apt_pkg.name.capitalize()
+
+        if not self.display_name:
+            self.display_name = self.name.capitalize()
+
+        self.display_name = self.display_name.replace(":i386", "")
+
+        return self.display_name
+
+    def get_summary(self, apt_pkg=None):
+        # fastest
+        if self.summary:
+            return self.summary
+
+        if apt_pkg and apt_pkg.candidate:
+            candidate = apt_pkg.candidate
+
+            summary = ""
+            if candidate.summary is not None:
+                summary = candidate.summary
+                summary = summary.replace("<", "&lt;")
+                summary = summary.replace("&", "&amp;")
+
+                self.summary = capitalize(summary)
+
+        if self.summary == None:
+            self.summary = ""
+
+        return self.summary
+
+    def get_description(self, apt_pkg=None):
+        # fastest
+        if self.description:
+            return self.description
+
+        if apt_pkg and apt_pkg.candidate:
+            candidate = apt_pkg.candidate
+
+            description = ""
+            if candidate.description != None:
+                description = candidate.description
+                description = description.replace("<p>", "").replace("</p>", "\n")
+                for tags in ["<ul>", "</ul>", "<li>", "</li>"]:
+                    description = description.replace(tags, "")
+
+                self.description = capitalize(description)
+
+        if self.description == None:
+            self.description = ""
+
+        return self.description
+
+    def get_icon(self, apt_pkg=None):
+        return None # this is handled in mintinstall directly for now
+
+    def get_screenshots(self, apt_pkg=None):
+        return [] # handled in mintinstall for now
+
+    def get_version(self, apt_pkg=None):
+        if self.version:
+            return self.version
+
+        if apt_pkg:
+            if apt_pkg.is_installed:
+                self.version = apt_pkg.installed.version
+            else:
+                self.version = apt_pkg.candidate.version
+
+            if self.version == None:
+                self.version = ""
+
+        return self.version
+
+    def get_url(self, apt_pkg=None):
+        if self.url:
+            return self.url
+
+        if apt_pkg:
+            if apt_pkg.is_installed:
+                self.url = apt_pkg.installed.homepage
+            else:
+                self.url = apt_pkg.candidate.homepage
+
+        if self.url == None:
+            self.url = ""
+
+        return self.url
+
+
+class FlatpakPkgInfo(PkgInfo):
+    def __init__(self, pkg_hash, remote, ref, remote_url, installed):
+        super(FlatpakPkgInfo, self).__init__(pkg_hash)
+
+        self.name = ref.get_name() # org.foo.Bar
+        self.remote = remote # "flathub"
+        self.remote_url = remote_url
+
+        self.refid = ref.format_ref() # app/org.foo.Bar/x86_64/stable
+        self.kind = ref.get_kind() # Will be app for now
+        self.arch = ref.get_arch()
+        self.branch = ref.get_branch()
+        self.commit = ref.get_commit()
+
+    def get_display_name(self, as_component=None):
+        # fastest
+        if self.display_name:
+            return self.display_name
+
+        if as_component:
+            display_name = as_component.get_name()
+
+            if display_name != None:
+                self.display_name = capitalize(display_name)
+
+        if self.display_name == None:
+            self.display_name = self.name
+
+        return self.display_name
+
+    def get_summary(self, as_component=None):
+        # fastest
+        if self.summary:
+            return self.summary
+
+        if as_component:
+            summary = as_component.get_summary()
+
+            if summary != None:
+                self.summary = summary
+
+        if self.summary == None:
+            self.summary = ""
+
+        return self.summary
+
+    def get_description(self, as_component=None):
+        # fastest
+        if self.description:
+            return self.description
+
+        if as_component:
+            description = as_component.get_description()
+
+            if description != None:
+                description = description.replace("<p>", "").replace("</p>", "\n")
+                for tags in ["<ul>", "</ul>", "<li>", "</li>"]:
+                    description = description.replace(tags, "")
+                self.description = capitalize(description)
+
+        if self.description == None:
+            self.description = ""
+
+        return self.description
+
+    def get_icon(self, as_component=None):
+        if self.icon:
+            return self.icon
+
+        if as_component:
+            icons = as_component.get_icons()
+
+            if icons:
+                if icons[0].get_kind() == AppStream.IconKind.LOCAL:
+                    self.icon = icons[0].get_filename()
+                elif icons[0].get_kind() == AppStream.IconKind.STOCK:
+                    self.icon = icons[0].get_name()
+
+        if self.icon == None:
+            self.icon = self.name
+
+        return self.icon
+
+    def get_screenshots(self, as_component=None):
+        if len(self.screenshots) > 0:
+            return self.screenshots
+
+        if as_component:
+            screenshots = as_component.get_screenshots()
+
+            for ss in screenshots:
+                images = ss.get_images()
+
+                if len(images) == 0:
+                    continue
+
+                # FIXME: there must be a better way.  Finding an optimal size to use without just
+                # resorting to an original source.
+
+                best = None
+                largest = None
+
+                for image in images:
+                    if image.get_kind() == AppStream.ImageKind.SOURCE:
+                        continue
+
+                    w = image.get_width()
+
+                    if w > 500 and w < 625:
+                        best = image
+                        break
+
+                    if w > 625:
+                        continue
+
+                    if largest == None or (largest != None and largest.get_width() < w):
+                        largest = image
+
+                if best == None and largest == None:
+                    continue
+
+                if best == None:
+                    best = largest
+
+                if ss.get_kind() == AppStream.ScreenshotKind.DEFAULT:
+                    self.screenshots.insert(0, best.get_url())
+                else:
+                    self.screenshots.append(best.get_url())
+
+        return self.screenshots
+
+    def get_version(self, as_component=None):
+        if self.version:
+            return self.version
+
+        if as_component:
+            releases = as_component.get_releases()
+
+            if len(releases) > 0:
+                version = releases[0].get_version()
+
+                if version:
+                    self.version = version
+
+        if self.version == None:
+            self.version = ""
+
+        return self.version
+
+    def get_url(self, as_component=None):
+        if self.url:
+            return self.url
+
+        if as_component:
+            url = as_component.get_url(AppStream.UrlKind.HOMEPAGE)
+
+            if url != None:
+                self.url = url
+
+        if self.url == None:
+            self.url = self.remote_url
+
+        return self.url

--- a/usr/lib/linuxmint/mintinstall/mintinstall-remove-app.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall-remove-app.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+import sys
+import os
+import gettext
+import subprocess
+
+from pathlib import Path
+from installer import installer
+
+# i18n
+gettext.install("mintinstall", "/usr/share/linuxmint/locale")
+
+class AppUninstaller:
+    def __init__(self, desktopFile):
+        self.desktopFile = desktopFile
+
+        self.installer = installer.Installer().init(self.on_installer_ready)
+
+    def on_installer_ready(self):
+        pkg_name = None
+
+        pkg_name = self.get_apt_name()
+
+        if pkg_name == None:
+            pkg_name = self.get_fp_name()
+
+        if pkg_name == None:
+            print("Package for '%s' not found")
+            self.on_finished()
+
+        pkginfo = self.installer.find_pkginfo(pkg_name)
+
+        if pkginfo and self.installer.pkginfo_is_installed(pkginfo):
+            self.installer.select_pkginfo(pkginfo, self.on_installer_ready_to_remove)
+        else:
+            print("Package '%s' is not installed")
+            self.on_finished()
+
+    def on_installer_ready_to_remove(self, task):
+        self.installer.execute_task(task, self.on_finished)
+
+    def get_apt_name(self):
+        (status, output) = subprocess.getstatusoutput("dpkg -S " + self.desktopFile)
+        package = output[:output.find(":")].split(",")[0]
+
+        if status == 0:
+            return package
+        else:
+            return None
+
+    def get_fp_name(self):
+        path = Path(self.desktopFile)
+
+        if "flatpak" not in path.parts:
+            return None
+
+        return path.stem
+
+    def on_finished(self, pkginfo=None, error=None):
+        Gtk.main_quit()
+
+if __name__ == "__main__":
+
+    # Exit if the given path does not exist
+    if len(sys.argv) < 2 or not os.path.exists(sys.argv[1]) or not sys.argv[1].endswith(".desktop"):
+        print("mintinstall-remove-app: Single argument required, the full path of a desktop file.")
+        sys.exit(1)
+
+    mainwin = AppUninstaller(sys.argv[1])
+    Gtk.main()

--- a/usr/lib/linuxmint/mintinstall/mintinstall-update-pkgcache.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall-update-pkgcache.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+
+
+from installer import cache
+
+pkgcache = cache.PkgCache()
+
+try:
+    pkgcache.force_new_cache()
+except Exception as e:
+    print(e)
+
+exit()

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -25,6 +25,7 @@ from gi.repository import Gtk, Gdk, GdkPixbuf, GObject, GLib, Gio, Flatpak, AppS
 
 from installer import installer
 import reviews
+import housekeeping
 
 ICON_SIZE = 48
 
@@ -681,6 +682,7 @@ class Application(Gtk.Application):
         GObject.idle_add(self.process_unmatched_packages)
 
         self.review_cache = reviews.ReviewCache()
+        housekeeping.run()
 
     def load_featured_on_landing(self):
         box = self.builder.get_object("box_featured")

--- a/usr/lib/linuxmint/mintinstall/misc.py
+++ b/usr/lib/linuxmint/mintinstall/misc.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+
+import os
+import time
+
+DEBUG_MODE = os.getenv("MINTINSTALL_DEBUG", False)
+
+# Used as a decorator to time functions
+def print_timing(func):
+    if not DEBUG_MODE:
+        return func
+    else:
+        def wrapper(*arg):
+            t1 = time.time()
+            res = func(*arg)
+            t2 = time.time()
+            print('%s took %0.3f ms' % (func.__qualname__, (t2 - t1) * 1000.0))
+            return res
+        return wrapper

--- a/usr/lib/linuxmint/mintinstall/reviews.py
+++ b/usr/lib/linuxmint/mintinstall/reviews.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python3
+# encoding=utf8
+# -*- coding: UTF-8 -*-
+
+import os
+import threading
+import time
+import pickle
+import requests
+import multiprocessing
+import signal
+
+from pathlib import Path
+
+from gi.repository import GLib
+
+REVIEWS_CACHE = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "reviews.cache")
+
+def print_timing(func):
+    def wrapper(*arg):
+        t1 = time.time()
+        res = func(*arg)
+        t2 = time.time()
+        print('%s took %0.3f ms' % (func.__name__, (t2 - t1) * 1000.0))
+        return res
+    return wrapper
+
+class ReviewInfo:
+    def __init__(self, name):
+        self.name = name
+        self.reviews = []
+        self.categories = []
+        self.score = 0
+        self.avg_rating = 0
+        self.num_reviews = 0
+
+    def update_stats(self):
+        points = 0
+        sum_rating = 0
+        self.num_reviews = len(self.reviews)
+        self.avg_rating = 0
+        for review in self.reviews:
+            points = points + (review.rating - 3)
+            sum_rating = sum_rating + review.rating
+        if self.num_reviews > 0:
+            self.avg_rating = round(float(sum_rating) / float(self.num_reviews), 1)
+        self.score = points
+
+class Review(object):
+    __slots__ = 'date', 'packagename', 'username', 'rating', 'comment', 'package' #To remove __dict__ memory overhead
+
+    def __init__(self, packagename, date, username, rating, comment):
+        self.date = date
+        self.packagename = packagename
+        self.username = username
+        self.rating = int(rating)
+        self.comment = comment
+        self.package = None
+
+class PickleObject(object):
+    def __init__(self, cache, size):
+        super(PickleObject, self).__init__()
+
+        self.cache = cache
+        self.size = int(size)
+
+class ReviewCache(object):
+    @print_timing
+    def __init__(self):
+        super(ReviewCache, self).__init__()
+
+        self._cache_lock = threading.Lock()
+
+        self._reviews, self._size = self._load_cache()
+
+        self._update_cache()
+
+    def keys(self):
+        with self._cache_lock:
+            return self._reviews.keys()
+
+    def values(self):
+        with self._cache_lock:
+            return self._reviews.values()
+
+    def __getitem__(self, key):
+        with self._cache_lock:
+            try:
+                return self._reviews[key]
+            except KeyError:
+                return ReviewInfo(key)
+
+    def __contains__(self, name):
+        with self._cache_lock:
+            return (name in self._reviews)
+
+    def __len__(self):
+        with self._cache_lock:
+            return len(self._reviews)
+
+    def _load_cache(self):
+        cache = None
+        size = 0
+
+        path = None
+
+        try:
+            path = Path(REVIEWS_CACHE)
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            path = None
+        finally:
+            if path != None:
+                try:
+                    with path.open(mode='rb') as f:
+                        pobj = pickle.load(f)
+
+                        cache = pobj.cache
+                        size = pobj.size
+                except Exception as e:
+                    print(e)
+                    cache = None
+
+        return cache, size
+
+    def _save_cache(self, cache, size):
+        path = None
+
+        try:
+            path = Path(REVIEWS_CACHE)
+            path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            path = None
+        finally:
+            try:
+                with path.open(mode='wb') as f:
+                    pobj = PickleObject(cache, size)
+                    pickle.dump(pobj, f)
+            except Exception as e:
+                print("Could not save review cache:", str(e))
+
+    def _update_cache(self):
+        thread = threading.Thread(target=self._update_reviews_thread)
+        thread.start()
+
+    @print_timing
+    def _update_reviews_thread(self):
+        # Update the review cache in a separate process.  Just doing it in a thread
+        # would end up blocking ui, due to the GIL problem.  But we can use this thread
+        # to monitor the Process and then reload the cache here once it terminates.
+
+        success = multiprocessing.Value('b', False)
+
+        current_size = multiprocessing.Value('d', self._size)
+        proc = multiprocessing.Process(target=self._update_cache_process, args=(success, current_size))
+
+        proc.start()
+        proc.join()
+
+        if success.value == True:
+            with self._cache_lock:
+                self._reviews, self._size = self._load_cache()
+
+    def _update_cache_process(self, success, current_size):
+        new_reviews = {}
+
+        try:
+            r = requests.head("https://community.linuxmint.com/data/new-reviews.list")
+
+            if r.status_code == 200:
+                if int(r.headers.get("content-length")) != current_size.value:
+
+                    r = requests.get("https://community.linuxmint.com/data/new-reviews.list")
+
+                    last_package = None
+
+                    for line in r.iter_lines():
+                        decoded = line.decode()
+
+                        elements = decoded.split("~~~")
+                        if len(elements) == 5:
+                            review = Review(elements[0], float(elements[1]), elements[2], elements[3], elements[4])
+                            if last_package != None and last_package.name == elements[0]:
+                                #Comment is on the same package as previous comment.. no need to search for the package
+                                last_package.reviews.append(review)
+                                review.package = last_package
+                            else:
+                                if last_package is not None:
+                                    last_package.update_stats()
+
+                                try:
+                                    package = new_reviews[elements[0]]
+                                except Exception:
+                                    package = ReviewInfo(elements[0])
+                                    new_reviews[elements[0]] = package
+
+                                last_package = package
+                                package.reviews.append(review)
+                                review.package = package
+
+                    if last_package is not None:
+                        last_package.update_stats()
+
+                    self._save_cache(new_reviews, r.headers.get("content-length"))
+                    print("Downloaded new reviews")
+                    success.value = True
+                else:
+                    print("No new reviews")
+            else:
+                print("Could not download updated reviews: %s" % r.reason)
+                success.value = False
+        except Exception as e:
+            print("Problem attempting to access reviews url: %s" % str(e))
+
+# Debugging - you can run reviews.py on its own, and inspect the ReviewCache (i)
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    i = ReviewCache()
+
+    import readline
+    import code
+    variables = globals().copy()
+    variables.update(locals())
+    shell = code.InteractiveConsole(variables)
+    shell.interact()
+
+    ml = GLib.MainLoop.new(None, True)
+    ml.run()

--- a/usr/share/applications/mintinstall-fp-handler.desktop
+++ b/usr/share/applications/mintinstall-fp-handler.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Software Manager
+Comment=Mime handler for mintinstall
+Exec=mintinstall-fp-handler %u
+Icon=mintinstall
+Terminal=false
+Type=Application
+Encoding=UTF-8
+NoDisplay=true
+MimeType=application/vnd.flatpak.ref

--- a/usr/share/glib-2.0/schemas/com.linuxmint.install.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.install.gschema.xml
@@ -16,5 +16,9 @@
       <summary></summary>
       <description></description>
     </key>
+    <key type="b" name="search-in-category">
+      <default>true</default>
+      <summary>Remembers the state of the 'search in category' button</summary>
+    </key>
   </schema>
 </schemalist>

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkSpinner" id="active_tasks_spinner">
@@ -31,10 +31,15 @@
     <property name="can_focus">False</property>
     <property name="icon_name">software-properties</property>
   </object>
-  <object class="GtkImage" id="subsearch_image">
+  <object class="GtkImage" id="image5">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">category-search-symbolic</property>
+    <property name="icon_name">go-previous-symbolic</property>
+  </object>
+  <object class="GtkImage" id="image6">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">open-menu-symbolic</property>
   </object>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
@@ -42,6 +47,9 @@
     <property name="default_width">800</property>
     <property name="default_height">600</property>
     <property name="gravity">center</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkVBox" id="vbox4">
         <property name="visible">True</property>
@@ -50,60 +58,22 @@
           <object class="GtkToolbar" id="toolbar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="toolbar_style">both-horiz</property>
             <property name="icon_size">4</property>
             <child>
-              <object class="GtkToolButton" id="back_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_underline">True</property>
-                <property name="icon_name">go-previous-symbolic</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolButton" id="active_tasks_button">
-                <property name="name">active_tasks_button</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">toolbutton</property>
-                <property name="use_underline">True</property>
-                <property name="icon_widget">active_tasks_spinner</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparatorToolItem" id="spacing">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="draw">False</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolItem" id="search_tool_item">
+              <object class="GtkToolItem">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkSearchEntry" id="search_entry">
+                      <object class="GtkButton" id="back_button">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="primary_icon_name">edit-find-symbolic</property>
-                        <property name="primary_icon_activatable">False</property>
-                        <property name="primary_icon_sensitive">False</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">image5</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -112,12 +82,12 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkToggleButton" id="subsearch_toggle">
+                      <object class="GtkButton" id="active_tasks_button">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Limit search to current listing</property>
-                        <property name="image">subsearch_image</property>
+                        <property name="image">active_tasks_spinner</property>
+                        <property name="always_show_image">True</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -125,26 +95,68 @@
                         <property name="position">1</property>
                       </packing>
                     </child>
-                    <style>
-                      <class name="linked"/>
-                    </style>
+                    <child>
+                      <object class="GtkButton" id="menu_button">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="image">image6</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="search_tool_item">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkSearchEntry" id="search_entry">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="primary_icon_name">edit-find-symbolic</property>
+                            <property name="primary_icon_activatable">False</property>
+                            <property name="primary_icon_sensitive">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkToggleButton" id="subsearch_toggle">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Limit search to current listing</property>
+                            <property name="image">subsearch_image</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="linked"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolButton" id="menu_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="use_underline">True</property>
-                <property name="icon_name">open-menu-symbolic</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="homogeneous">True</property>
               </packing>
             </child>
@@ -1145,8 +1157,10 @@
         </child>
       </object>
     </child>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+  </object>
+  <object class="GtkImage" id="subsearch_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">category-search-symbolic</property>
   </object>
 </interface>

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -2,6 +2,11 @@
 <!-- Generated with glade 3.22.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
+  <object class="GtkSpinner" id="active_tasks_spinner">
+    <property name="name">active_tasks_spinner</property>
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+  </object>
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -26,121 +31,72 @@
     <property name="can_focus">False</property>
     <property name="icon_name">software-properties</property>
   </object>
+  <object class="GtkImage" id="subsearch_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">category-search-symbolic</property>
+  </object>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="window_position">center</property>
     <property name="default_width">800</property>
     <property name="default_height">600</property>
+    <property name="gravity">center</property>
     <child>
       <object class="GtkVBox" id="vbox4">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <object class="GtkVBox" id="toolbar">
+          <object class="GtkToolbar" id="toolbar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="toolbar_style">both-horiz</property>
+            <property name="icon_size">4</property>
             <child>
-              <object class="GtkButtonBox" id="buttonbox1">
+              <object class="GtkToolButton" id="back_button">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="valign">baseline</property>
-                <property name="border_width">6</property>
+                <property name="use_underline">True</property>
+                <property name="icon_name">go-previous-symbolic</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToolButton" id="active_tasks_button">
+                <property name="name">active_tasks_button</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">toolbutton</property>
+                <property name="use_underline">True</property>
+                <property name="icon_widget">active_tasks_spinner</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSeparatorToolItem" id="spacing">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="draw">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToolItem" id="search_tool_item">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkBox" id="loading_parent">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkButton" id="back_button">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="halign">start</property>
-                        <property name="hexpand">False</property>
-                        <property name="always_show_image">True</property>
-                        <child>
-                          <object class="GtkImage" id="image6">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">go-previous-symbolic</property>
-                            <property name="icon_size">2</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="loading_box">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="loading_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Loading package info...</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSpinner" id="loading_spinner">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="active">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="box10">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
-                      <object class="GtkMenuButton" id="menu_button">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <child>
-                          <object class="GtkImage" id="image5">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">open-menu-symbolic</property>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="pack_type">end</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
                     <child>
                       <object class="GtkSearchEntry" id="search_entry">
                         <property name="visible">True</property>
@@ -152,22 +108,44 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="pack_type">end</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkToggleButton" id="subsearch_toggle">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Limit search to current listing</property>
+                        <property name="image">subsearch_image</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
+                    <style>
+                      <class name="linked"/>
+                    </style>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToolButton" id="menu_button">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="use_underline">True</property>
+                <property name="icon_name">open-menu-symbolic</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="homogeneous">True</property>
               </packing>
             </child>
             <style>
@@ -185,6 +163,45 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="transition_type">crossfade</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">center</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">&lt;big&gt;&lt;b&gt;Generating cache, one moment&lt;/b&gt;&lt;/big&gt;</property>
+                    <property name="use_markup">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner" id="loading_spinner">
+                    <property name="height_request">50</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="active">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">loading</property>
+                <property name="title" translatable="yes">page0</property>
+              </packing>
+            </child>
             <child>
               <object class="GtkBox" id="box_landing">
                 <property name="visible">True</property>
@@ -278,6 +295,7 @@
               <packing>
                 <property name="name">landing</property>
                 <property name="title" translatable="yes">page0</property>
+                <property name="position">1</property>
               </packing>
             </child>
             <child>
@@ -312,26 +330,19 @@
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkRevealer" id="list_header_revealer">
+                      <object class="GtkLabel" id="label_cat_name">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="reveal_child">True</property>
-                        <child>
-                          <object class="GtkLabel" id="label_cat_name">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_top">6</property>
-                            <property name="margin_bottom">6</property>
-                            <property name="xpad">6</property>
-                            <property name="ypad">12</property>
-                            <property name="xalign">0</property>
-                            <property name="yalign">0</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                              <attribute name="scale" value="1.2"/>
-                            </attributes>
-                          </object>
-                        </child>
+                        <property name="margin_top">6</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="xpad">6</property>
+                        <property name="ypad">12</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -347,37 +358,61 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">2</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkScrolledWindow" id="scrolledwindow_applications">
+                      <object class="GtkStack" id="app_list_stack">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="transition_type">crossfade</property>
                         <child>
-                          <object class="GtkViewport" id="viewport3">
+                          <object class="GtkScrolledWindow" id="scrolledwindow_applications">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can_focus">True</property>
                             <child>
-                              <object class="GtkBox" id="box_cat_page">
+                              <object class="GtkViewport" id="viewport3">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
+                                  <object class="GtkBox" id="box_cat_page">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                    <child>
+                                      <placeholder/>
+                                    </child>
+                                  </object>
                                 </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="name">results</property>
+                            <property name="title" translatable="yes">page0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="no_packages_found_label">
+                            <property name="name">no_packages_found_label</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="use_markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="name">no-results</property>
+                            <property name="title" translatable="yes">page1</property>
+                            <property name="position">1</property>
+                          </packing>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">3</property>
+                        <property name="position">2</property>
                       </packing>
                     </child>
                   </object>
@@ -391,7 +426,7 @@
               <packing>
                 <property name="name">list</property>
                 <property name="title" translatable="yes">page1</property>
-                <property name="position">1</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -400,60 +435,23 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkRevealer" id="detail_header_revealer">
+                  <object class="GtkBox" id="box_application_header">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="reveal_child">True</property>
+                    <property name="margin_top">6</property>
+                    <property name="margin_bottom">6</property>
+                    <property name="spacing">12</property>
                     <child>
-                      <object class="GtkBox" id="box_application_header">
+                      <object class="GtkBox" id="box6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">6</property>
-                        <property name="margin_right">6</property>
-                        <property name="margin_top">6</property>
-                        <property name="margin_bottom">6</property>
-                        <property name="spacing">12</property>
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">6</property>
                         <child>
-                          <object class="GtkBox" id="box6">
+                          <object class="GtkImage" id="application_icon">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkImage" id="application_icon">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="stock">gtk-missing-image</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box7">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
+                            <property name="stock">gtk-missing-image</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -462,19 +460,81 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="box3">
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box7">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkLabel" id="application_name">
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="box3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="application_name">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="xalign">0</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="application_summary">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="xalign">0</property>
+                            <property name="yalign">0</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box_star_reviews">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkBox" id="box_stars">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                  <attribute name="scale" value="1.2"/>
-                                </attributes>
+                                <child>
+                                  <placeholder/>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -483,231 +543,171 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="application_summary">
+                              <object class="GtkLabel" id="application_avg_rating">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="yalign">0</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                  <attribute name="scale" value="1"/>
+                                </attributes>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
-                                <property name="fill">True</property>
+                                <property name="fill">False</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="box_star_reviews">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkBox" id="box_stars">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="application_avg_rating">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                      <attribute name="scale" value="1"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box8">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkLabel" id="application_num_reviews">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkNotebook" id="notebook_progress">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="valign">center</property>
-                            <property name="show_tabs">False</property>
-                            <property name="show_border">False</property>
-                            <child>
-                              <object class="GtkBox" id="box9">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkButton" id="launch_button">
-                                    <property name="label" translatable="yes">Launch</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="valign">center</property>
-                                    <property name="vexpand">False</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="action_button">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="valign">center</property>
-                                    <property name="vexpand">False</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="tab">
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box11">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel" id="application_progress_label">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Installing</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkProgressBar" id="application_progress">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
-                              <placeholder/>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="box12">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <property name="spacing">4</property>
-                                <child>
-                                  <object class="GtkLabel" id="label1">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Please be patient. This can take some time...</property>
-                                    <property name="label" translatable="yes">Installing additional dependencies</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinner" id="spinner_progress">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Please be patient. This can take some time...</property>
-                                    <property name="active">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child type="tab">
                               <placeholder/>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="fill">True</property>
                             <property name="position">2</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkBox" id="box8">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkLabel" id="application_num_reviews">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">1</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
                       </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkNotebook" id="notebook_progress">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">center</property>
+                        <property name="show_tabs">False</property>
+                        <property name="show_border">False</property>
+                        <child>
+                          <object class="GtkBox" id="box9">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">6</property>
+                            <child>
+                              <object class="GtkButton" id="launch_button">
+                                <property name="label" translatable="yes">Launch</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="valign">center</property>
+                                <property name="vexpand">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="action_button">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="valign">center</property>
+                                <property name="vexpand">False</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="tab">
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="progress_box">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="valign">center</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkProgressBar" id="application_progress">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="valign">center</property>
+                                <property name="pulse_step">1</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="box12">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkSpinner" id="spinner_progress">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Please be patient. This can take some time...</property>
+                                <property name="active">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="padding">6</property>
+                        <property name="position">2</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
@@ -1052,30 +1052,10 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="application_flatpak">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">3</property>
-                                  </packing>
+                                  <placeholder/>
                                 </child>
                                 <child>
-                                  <object class="GtkLabel" id="label_flatpak">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Flatpak</property>
-                                    <property name="xalign">0</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">3</property>
-                                  </packing>
+                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
@@ -1146,14 +1126,14 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="name">details</property>
                 <property name="title" translatable="yes">page2</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
           </object>


### PR DESCRIPTION
Trying to simplify package handling in mintinstall so that all package types can be treated the same from a UI perspective.  This is accomplished, more or less, except for a few items shown in the package details view that there aren't equivalents for between apt and flatpaks.

See commits for more details.
