### PR TITLE
UI: Add a small margin between the application icon and window edge

### DIFF
--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -41,6 +41,11 @@
     <property name="can_focus">False</property>
     <property name="icon_name">open-menu-symbolic</property>
   </object>
+  <object class="GtkImage" id="subsearch_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">category-search-symbolic</property>
+  </object>
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="window_position">center</property>
@@ -457,6 +462,7 @@
                       <object class="GtkBox" id="box6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="margin_left">6</property>
                         <property name="orientation">vertical</property>
                         <property name="spacing">6</property>
                         <child>
@@ -1157,10 +1163,5 @@
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="subsearch_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">category-search-symbolic</property>
   </object>
 </interface>


### PR DESCRIPTION
Gives us a small bit of space here:
![selection_018](https://user-images.githubusercontent.com/2231759/39696837-da2a8172-51a3-11e8-9498-7dbc06bf31fe.png)

So the icon isn't right against the window edge.
