### PR TITLE
Various fixes mainly for flatpak

### DIFF
--- a/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
@@ -242,6 +242,12 @@ def _is_ref_installed(fp_sys, ref):
     return False
 
 def _get_remote_sizes(fp_sys, remote, ref):
+    # Since 0.11.4, this info is part of FlatpakRemoteRef
+    # dl_s = ref.props.download_size
+    # inst_s = ref.props.installed_size
+    # But it appears to always contain identical dl and installed sizes,
+    # so avoid it for now.
+
     try:
         success, dl_s, inst_s = fp_sys.fetch_remote_size_sync(remote,
                                                               ref,
@@ -290,7 +296,7 @@ def _add_ref_to_task(fp_sys, task, ref, needs_update=False):
         dl_s, inst_s = _get_remote_sizes(fp_sys, ref.get_remote_name(), ref)
 
         task.download_size += dl_s
-        task.install_size = inst_s
+        task.install_size += inst_s
     elif task.type == "remove":
         _add_to_list(task.to_remove, ref)
         task.freed_size += _get_installed_size(fp_sys, ref)

--- a/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
@@ -25,7 +25,7 @@ class FlatpakRemoteInfo():
         self.noenumerate = remote.get_noenumerate()
 
         if not self.title or self.title == "":
-            self.title = name.capitalize()
+            self.title = self.name.capitalize()
 
 _fp_sys = None
 
@@ -1079,6 +1079,8 @@ class MetaTransaction():
         GLib.idle_add(self.task.error_cleanup_cb, self.task)
 
     def on_flatpak_finished(self):
+        self.fp_sys.drop_caches(None)
+
         GLib.idle_add(self.task.finished_cleanup_cb, self.task)
 
 

--- a/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
@@ -716,6 +716,22 @@ def find_pkginfo(cache, string):
 
     return None
 
+def generate_uncached_pkginfos(cache):
+    fp_sys = get_fp_sys()
+
+    try:
+        for remote in fp_sys.list_remotes():
+            remote_name = remote.get_name()
+
+            for ref in fp_sys.list_installed_refs_by_kind(Flatpak.RefKind.APP, None):
+                # All remotes will see installed refs, but the installed refs will always
+                # report their correct origin, so only add installed refs when they match the remote.
+                if ref.get_origin() == remote_name:
+                    _add_package_to_cache(cache, ref, remote.get_url(), True)
+
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not check for uncached pkginfos", e.message)
+
 def pkginfo_is_installed(pkginfo):
     fp_sys = get_fp_sys()
 

--- a/usr/lib/linuxmint/mintinstall/installer/cache.py
+++ b/usr/lib/linuxmint/mintinstall/installer/cache.py
@@ -75,6 +75,10 @@ class PkgCache(object):
         with self._item_lock:
             self._items[key] = value
 
+    def __delitem__(self, key):
+        with self._item_lock:
+            del self._items[key]
+
     def __contains__(self, pkg_hash):
         with self._item_lock:
             return pkg_hash in self._items

--- a/usr/lib/linuxmint/mintinstall/installer/installer.py
+++ b/usr/lib/linuxmint/mintinstall/installer/installer.py
@@ -319,8 +319,8 @@ class Installer:
 
     def list_flatpak_remotes(self):
         """
-        Returns a list of tuples of (remote name, remote title).  The remote_name
-        can be used to match with PkgInfo.remote and the title is for display.
+        Returns a list of FlatpakRemoteInfos.  The remote_name can be used to match
+        with PkgInfo.remote and the title is for display.
         """
         return _flatpak.list_remotes()
 

--- a/usr/lib/linuxmint/mintinstall/installer/installer.py
+++ b/usr/lib/linuxmint/mintinstall/installer/installer.py
@@ -148,6 +148,7 @@ class Installer:
             self.inited = True
 
             GObject.idle_add(self.initialize_appstream)
+            self.generate_uncached_pkginfos(self.cache)
 
             return True
 
@@ -184,6 +185,8 @@ class Installer:
             self.remotes_changed = False
 
         GObject.idle_add(self.initialize_appstream)
+
+        self.generate_uncached_pkginfos(self.cache)
 
         print('Full installer startup took %0.3f ms' % ((time.time() - self.startup_timer) * 1000.0))
 
@@ -333,6 +336,15 @@ class Installer:
                 return _flatpak.pkginfo_is_installed(pkginfo)
 
         return False
+
+    @print_timing
+    def generate_uncached_pkginfos(self, cache):
+        """
+        Flatpaks installed from .flatpakref files may not actually be in the saved
+        pkginfo cache, specifically, if they're added from no-enumerate-marked remotes.
+        This gets run at startup to collect and generate their info.
+        """
+        _flatpak.generate_uncached_pkginfos(cache)
 
     @print_timing
     def initialize_appstream(self):


### PR DESCRIPTION
- Avoids problematic api where possible
- track installed apps more accurately (becomes an issue with multiple potential sources of apps)
- allow one-off installed flatpaks to be displayed and uninstalled (generate installed, but not cached, flatpaks at startup

various other.

Tested on flatpak 0.11.3, 0.11.7, 0.99.2