### PR TITLE
_apt.py: whitelist libimage-exiftool-perl

### DIFF
--- a/usr/lib/linuxmint/mintinstall/installer/_apt.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_apt.py
@@ -61,7 +61,7 @@ def process_full_apt_cache(cache):
     for key in keys:
         name = apt_cache[key].name
 
-        if name.startswith("lib") and not name.startswith(("libreoffice", "librecad", "libk3b7")):
+        if name.startswith("lib") and not name.startswith(("libreoffice", "librecad", "libk3b7", "libimage-exiftool-perl")):
             continue
         if name.endswith(":i386") and name != "steam:i386":
             continue


### PR DESCRIPTION
Fixes #213 