### PR TITLE
all: Don't require flatpak to be installed.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,6 @@ Depends: python3 (>= 3.4),
          python3-configobj,
          python3-setproctitle,
          gir1.2-appstream-1.0,
-         gir1.2-flatpak-1.0,
          gir1.2-gdkpixbuf-2.0,
          gir1.2-glib-2.0,
          gir1.2-gtk-3.0,
@@ -23,7 +22,7 @@ Depends: python3 (>= 3.4),
          libgtk2-perl,
          mint-common,
          app-install-data,
-         flatpak,
          xdg-desktop-portal-gtk
+Recommends: gir1.2-flatpak-1.0, flatpak
 Description: Software Manager
  A software manager to easily install new applications.

--- a/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
+++ b/usr/lib/linuxmint/mintinstall/installer/_flatpak.py
@@ -9,7 +9,13 @@ import os
 
 import gi
 gi.require_version('AppStream', '1.0')
-from gi.repository import AppStream, Flatpak, GLib, GObject, Gtk, Gio
+from gi.repository import AppStream, GLib, GObject, Gtk, Gio
+
+try:
+    gi.require_version('Flatpak', '1.0')
+    from gi.repository import Flatpak
+except:
+    pass
 
 from installer.pkgInfo import FlatpakPkgInfo
 from installer import dialogs

--- a/usr/lib/linuxmint/mintinstall/installer/dialogs.py
+++ b/usr/lib/linuxmint/mintinstall/installer/dialogs.py
@@ -1,6 +1,6 @@
 import gi
 gi.require_version('XApp', '1.0')
-from gi.repository import GLib, Gtk, GObject, Gdk, XApp, Flatpak
+from gi.repository import GLib, Gtk, GObject, Gdk, XApp
 
 import gettext
 APP = 'mintinstall'


### PR DESCRIPTION
Clean up imports and exercise more caution when flatpak use is involved.
Only the _flatpak module will attempt to import it now, and behavior
elsewhere is adjusted when no remotes are found, including hiding the
flatpak category button.

Removed dependencies, added the necessary packages as recommends.

Mintinstall will need to be restarted once installing these packages
for support to live.  At this point a remote can be added successfully
via mimetype handler.

Fixes #192