### PR TITLE
Update layout to expand vertically on homescreen

### DIFF
--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -237,7 +237,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
@@ -303,7 +303,7 @@
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">5</property>
                   </packing>


### PR DESCRIPTION
Categories buttons and the top banner had a fixed size. They could only scale horizontally. Now they can also expand vertically, making the homescreen more responsive.

Preview attached below:
![preview](https://user-images.githubusercontent.com/88463576/128372670-b320970d-a8bd-4fad-b68b-e0bdd4bab8af.gif)
