### PR TITLE
UI: Use a listbox in some places instead of a flowbox

### DIFF
--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkSpinner" id="active_tasks_spinner">
@@ -405,6 +405,9 @@
                                 </child>
                               </object>
                             </child>
+                            <style>
+                              <class name="view"/>
+                            </style>
                           </object>
                           <packing>
                             <property name="name">results</property>


### PR DESCRIPTION
In the category and search views, the flowbox and buttons doesn't look
great. Escpecially in non-flat themes like Mint-X it can look overly busy.
Use a listbox for these views instead which gives a much cleaner and nicer
look.