### PR TITLE
Change Flathub repo URL to minimize TLS erros

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -35,7 +35,8 @@ case "$1" in
     then
         # flatpak remote-add --if-not-exists gnome https://sdk.gnome.org/gnome.flatpakrepo
         # flatpak remote-add --if-not-exists gnome-apps https://sdk.gnome.org/gnome-apps.flatpakrepo
-        flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        # flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         # Create share dirs for flatpak, they're in XDG_DATA_DIRS already but if they don't exist
         # they won't be monitored by some of the DEs and the first apps installed with Flatpak won't
         # show in the menu until the user logs out.


### PR DESCRIPTION
Change https://flathub.org/repo/flathub.flatpakrepo to https://dl.flathub.org/repo/flathub.flatpakrepo

The original https://flathub.org/repo/flathub.flatpakrepo is generating TLS errors