### PR TITLE
Improvements in appearance

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -890,7 +890,7 @@ class SubcategoryFlowboxChild(Gtk.FlowBoxChild):
 
         self.button.connect("clicked", self._activate_fb_child)
 
-        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, valign=Gtk.Align.START)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, valign=Gtk.Align.CENTER)
         image = Gtk.Image(icon_name=cat_icon, icon_size=Gtk.IconSize.MENU)
         label = Gtk.Label(label=cat_name)
         box.pack_start(image, False, False, 0)
@@ -913,7 +913,7 @@ class CategoryButton(Gtk.Button):
         self.set_can_focus(False)
         self.set_hexpand(True)
 
-        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, valign=Gtk.Align.START)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, valign=Gtk.Align.CENTER)
         image = Gtk.Image(icon_name=category.icon_name, icon_size=Gtk.IconSize.MENU)
         label = Gtk.Label(label=category.name)
         box.pack_start(image, False, False, 0)

--- a/usr/share/linuxmint/mintinstall/mintinstall.glade
+++ b/usr/share/linuxmint/mintinstall/mintinstall.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkSizeGroup"/>
@@ -463,6 +463,7 @@
                   <object class="GtkBox" id="box_subcategories">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="margin-top">5</property>
                     <child>
                       <placeholder/>
                     </child>


### PR DESCRIPTION
I centered the vertical text on the **category** buttons and **subcategories**.
Before:
![image](https://github.com/linuxmint/mintinstall/assets/23406555/83bfc722-449d-4e0e-9496-c7e4bbe47a0f)

After:
![image](https://github.com/linuxmint/mintinstall/assets/23406555/91e54fd6-01da-4f4a-b64c-1cb3216276d0)
The remaining buttons are centered, and I don't know why they shouldn't be centered as well.

I added margins to the subcategories, similar to the example in XED, because there was a lack of top spacing, which helps visually by adding some symmetry.
Before:
![Zrzut ekranu z 2023-05-21 17-27-12](https://github.com/linuxmint/mintinstall/assets/23406555/9cd6c952-4de3-4fa4-9d29-600622143503)
After:
![Zrzut ekranu z 2023-05-21 17-26-05](https://github.com/linuxmint/mintinstall/assets/23406555/ca75b227-6edc-4060-8bcd-91c38c695120)

