### PR TITLE
Added more readable flatpak name in the banner

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -635,7 +635,7 @@ class BannerTile(Gtk.FlowBoxChild):
                                                  Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
         label_name = Gtk.Label(xalign=0)
-        label_name.set_label(self.installer.get_display_name(pkginfo))
+        label_name.set_label(app_json['display_name'] or self.installer.get_display_name(pkginfo))
         label_name.set_name("BannerTitle")
 
         label_summary = Gtk.Label(xalign=0)

--- a/usr/share/linuxmint/mintinstall/featured/featured.json
+++ b/usr/share/linuxmint/mintinstall/featured/featured.json
@@ -1,110 +1,132 @@
 [
   {
+    "display_name": null,
     "name": "blender",
     "background": "linear-gradient(45deg, #FB8C00, #FFB74D)",
     "text_color": "#3C2C1C"
   },
   {
+    "display_name": null,
     "name": "sublime-text",
     "background": "radial-gradient(#7a4700 0.65px, #505050 0.65px) 0 0 / 13px 13px repeat, #ff9800",
     "text_color": "#f0f0f0"
   },
   {
+    "display_name": null,
     "name": "vlc",
     "background": "linear-gradient(135deg, #f38806 25%, #fb9006 25%, #fb9006 50%, #f38806 50%, #f38806 75%, #fb9006 75%, #fb9006 100%)",
     "text_color": "#3C2C1C"
   },
   {
+    "display_name": null,
     "name": "inkscape",
     "background": "radial-gradient(#66718c 0.65px, #4b4b50 0.65px) 0 0 / 13px 13px repeat, #66718c",
     "text_color": "#fefefe"
   },
   {
+    "display_name": null,
     "name": "gimp",
     "background": "radial-gradient(#DBB109 0.65px, #FECB00 0.65px) 0 0 / 13px 13px repeat, #FECB00",
     "text_color": "#333333"
   },
   {
+    "display_name": "Whatsie",
     "name": "flatpak:com.ktechpit.whatsie",
     "background": "linear-gradient(to top, #fefffe, #eeeeee)",
     "text_color": "#414141"
   },
   {
+    "display_name": null,
     "name": "spotify-client",
     "background": "linear-gradient(to top, #31d565, #1ed760)",
     "text_color": "#fffeff"
   },
   {
+    "display_name": null,
     "name": "audacity",
     "background": "linear-gradient(45deg, #f3df1b, #ff6c01)",
     "text_color": "#00003b"
   },
   {
+    "display_name": null,
     "name": "qbittorrent",
     "background": "linear-gradient(to right, #60A0E6, #4482CF)",
     "text_color": "#E6F3FC"
   },
   {
+    "display_name": null,
     "name": "steam:i386",
     "background": "radial-gradient(#6FBCE8 0.65px, transparent 0.65px) 0 0 / 13px 13px repeat, linear-gradient(to right, #11273D, #194761, #11273D), #11273D",
     "text_color": "#ffffff"
   },
   {
+    "display_name": null,
     "name": "dropbox",
     "background": "linear-gradient(to left, #004391, #1b63ad)",
     "text_color": "#ececec"
   },
   {
+    "display_name": null,
     "name": "filezilla",
     "background": "linear-gradient(to right, #b80000, #b80000)",
     "text_color": "#fffefb"
   },
   {
+    "display_name": null,
     "name": "google-earth-pro-stable",
     "background": "linear-gradient(to right, #013364, #024b90)",
     "text_color": "#ffffff"
   },
   {
+    "display_name": null,
     "name": "skypeforlinux",
     "background": "linear-gradient(45deg, #0267a4, #0281cb)",
     "text_color": "#ffffff"
   },
   {
+    "display_name": "Bitwarden",
     "name": "flatpak:com.bitwarden.desktop",
     "background": "radial-gradient(circle at center, #165ad5 0, #1052c9 100%)",
     "text_color": "#ffffff"
   },
   {
+    "display_name": "Telegram Desktop",
     "name": "flatpak:org.telegram.desktop",
     "background": "linear-gradient(to bottom, #1c8ad5, #51bae9)",
     "text_color": "#E6F3FC"
   },
   {
+    "display_name": "Discord",
     "name": "flatpak:com.discordapp.Discord",
     "background": "linear-gradient(45deg, #5567e3, #7289d9)",
     "text_color": "#ffffff"
   },
   {
+    "display_name": "Signal Desktop",
     "name": "flatpak:org.signal.Signal",
     "background": "linear-gradient(to bottom, #f7f7f7, #fafafa)",
     "text_color": "#1a1a1a"
   },
   {
+    "display_name": "Visual Studio Code",
     "name": "flatpak:com.visualstudio.code",
     "background": "linear-gradient(to right, #2d2c32, #2c2c32)",
     "text_color": "#fefefe"
   },
   {
+    "display_name": "Todoist: To-Do List & Tasks",
     "name": "flatpak:com.todoist.Todoist",
     "background": "#f5f5f5",
     "text_color": "#e44332"
   },
   {
+    "display_name": "Slack",
     "name": "flatpak:com.slack.Slack",
     "background": "linear-gradient(45deg, #f7f7f7, #f5f5f5)",
     "text_color": "#000000"
   },
   {
+    "display_name": "Zoom",
     "name": "flatpak:us.zoom.Zoom",
     "background": "linear-gradient(to right, #4a8cff, #4a8cff)",
     "text_color": "#ffffff"


### PR DESCRIPTION
I understand that more experienced flatpak users will understand that the name `com.todoist.Todoist` refers to the `Todoist: To-Do List & Tasks` application, but that may not be true for more lay users.

With that in mind, I added a `display_name` to each package in `featured.json` and filled it in all flatpaks to make it easier for the user to read and identify the package.