### PR TITLE
Add a setting to filter apt/Flatpak results for the same application, with a fix for search sorting

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -59,6 +59,11 @@ SEARCH_IN_DESCRIPTION = "search-in-description"
 INSTALLED_APPS = "installed-apps"
 SEARCH_IN_CATEGORY = "search-in-category"
 HAMONIKR_SCREENSHOTS = "hamonikr-screenshots"
+PACKAGE_TYPE_PREFERENCE = "search-package-type-preference"
+# Allowed values
+PACKAGE_TYPE_PREFERENCE_ALL = "all"
+PACKAGE_TYPE_PREFERENCE_APT = "apt"
+PACKAGE_TYPE_PREFERENCE_FLATPAK = "flatpak"
 
 # package type combobox columns
 # index, label, icon-name, tooltip, pkginfo
@@ -1210,6 +1215,25 @@ class Application(Gtk.Application):
         search_description_menuitem.show()
         submenu.append(search_description_menuitem)
 
+        package_type_preference_submenu = Gtk.Menu()
+        package_type_preference_group = None
+        for value, label in [
+            (PACKAGE_TYPE_PREFERENCE_ALL, _("Show all")),
+            (PACKAGE_TYPE_PREFERENCE_APT, _("Prefer system package")),
+            (PACKAGE_TYPE_PREFERENCE_FLATPAK, _("Prefer Flatpak")),
+        ]:
+            package_type_preference_submenuitem = Gtk.RadioMenuItem.new_with_label(package_type_preference_group, label)
+            package_type_preference_group = package_type_preference_submenuitem.get_group()
+            package_type_preference_submenuitem.set_active(self.settings.get_string(PACKAGE_TYPE_PREFERENCE) == value)
+            package_type_preference_submenuitem.connect("toggled", self.set_package_type_preference, value)
+            package_type_preference_submenuitem.show()
+            package_type_preference_submenu.append(package_type_preference_submenuitem)
+
+        package_type_preference_menuitem = Gtk.MenuItem(label=_("Package type preference in search results"))
+        package_type_preference_menuitem.set_submenu(package_type_preference_submenu)
+        package_type_preference_menuitem.show()
+        submenu.append(package_type_preference_menuitem)
+
         separator = Gtk.SeparatorMenuItem()
         separator.show()
         submenu.append(separator)
@@ -1944,6 +1968,14 @@ class Application(Gtk.Application):
         if (self.searchentry.get_text() != ""):
             self.show_search_results(terms)
 
+    def set_package_type_preference(self, radiomenuitem, value):
+        if radiomenuitem.get_active():
+            self.settings.set_string(PACKAGE_TYPE_PREFERENCE, value)
+
+            terms = self.searchentry.get_text()
+            if terms != "":
+                self.show_search_results(terms)
+
     def open_about(self, widget):
         dlg = Gtk.AboutDialog()
         dlg.set_transient_for(self.main_window)
@@ -2493,6 +2525,9 @@ class Application(Gtk.Application):
         search_in_summary = self.settings.get_boolean(SEARCH_IN_SUMMARY)
         search_in_description = self.settings.get_boolean(SEARCH_IN_DESCRIPTION)
 
+        package_type_preference = self.settings.get_string(PACKAGE_TYPE_PREFERENCE)
+        hidden_packages = set()
+
         def idle_search_one_package(pkginfos):
             try:
                 pkginfo = pkginfos.pop(0)
@@ -2500,17 +2535,19 @@ class Application(Gtk.Application):
                 self.search_idle_timer = 0
                 return False
 
+            is_match = False
+
             while True:
                 if all(piece in pkginfo.name.upper() for piece in termsSplit):
-                    searched_packages.append(pkginfo)
+                    is_match = True
                     pkginfo.search_tier = 0
                     break
                 if (search_in_summary and termsUpper in self.installer.get_summary(pkginfo, for_search=True).upper()):
-                    searched_packages.append(pkginfo)
+                    is_match = True
                     pkginfo.search_tier = 100
                     break
                 if(search_in_description and termsUpper in self.installer.get_description(pkginfo, for_search=True).upper()):
-                    searched_packages.append(pkginfo)
+                    is_match = True
                     pkginfo.search_tier = 200
                     break
                 # pkginfo.name for flatpaks is their id (org.foo.BarMaker), which
@@ -2518,10 +2555,17 @@ class Application(Gtk.Application):
                 # names are better. The 'name' is still checked first above, because
                 # it's static - get_display_name() may involve a lookup with appstream.
                 if pkginfo.pkg_hash.startswith("f") and all(piece in self.installer.get_display_name(pkginfo).upper() for piece in termsSplit):
-                    searched_packages.append(pkginfo)
+                    is_match = True
                     pkginfo.search_tier = 0
                     break
                 break
+
+            if is_match:
+                searched_packages.append(pkginfo)
+                if package_type_preference == PACKAGE_TYPE_PREFERENCE_APT and pkginfo.pkg_hash.startswith("a"):
+                    hidden_packages.add(FLATPAK_EQUIVS.get(pkginfo.name))
+                elif package_type_preference == PACKAGE_TYPE_PREFERENCE_FLATPAK and pkginfo.pkg_hash.startswith("f"):
+                    hidden_packages.add(DEB_EQUIVS.get(pkginfo.name))
 
             # Repeat until empty
             if len(pkginfos) > 0:
@@ -2529,7 +2573,14 @@ class Application(Gtk.Application):
 
             self.search_idle_timer = 0
 
-            GLib.idle_add(self.on_search_results_complete, searched_packages)
+            if package_type_preference == PACKAGE_TYPE_PREFERENCE_APT:
+                results = [p for p in searched_packages if not (p.pkg_hash.startswith("f") and p.name in hidden_packages)]
+            elif package_type_preference == PACKAGE_TYPE_PREFERENCE_FLATPAK:
+                results = [p for p in searched_packages if not (p.pkg_hash.startswith("a") and p.name in hidden_packages)]
+            else:
+                results = searched_packages
+
+            GLib.idle_add(self.on_search_results_complete, results)
             return False
 
         self.search_idle_timer = GLib.idle_add(idle_search_one_package, list(listing))

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1203,36 +1203,40 @@ class Application(Gtk.Application):
         separator.show()
         submenu.append(separator)
 
+        search_menuitem = Gtk.MenuItem(label=_("Search preferences"))
+        search_submenu = Gtk.Menu()
+        search_menuitem.set_submenu(search_submenu)
+        search_menuitem.show()
+        submenu.append(search_menuitem)
+
         search_summary_menuitem = Gtk.CheckMenuItem(label=_("Search in packages summary (slower search)"))
         search_summary_menuitem.set_active(self.settings.get_boolean(SEARCH_IN_SUMMARY))
         search_summary_menuitem.connect("toggled", self.set_search_filter, SEARCH_IN_SUMMARY)
         search_summary_menuitem.show()
-        submenu.append(search_summary_menuitem)
+        search_submenu.append(search_summary_menuitem)
 
         search_description_menuitem = Gtk.CheckMenuItem(label=_("Search in packages description (even slower search)"))
         search_description_menuitem.set_active(self.settings.get_boolean(SEARCH_IN_DESCRIPTION))
         search_description_menuitem.connect("toggled", self.set_search_filter, SEARCH_IN_DESCRIPTION)
         search_description_menuitem.show()
-        submenu.append(search_description_menuitem)
+        search_submenu.append(search_description_menuitem)
 
-        package_type_preference_submenu = Gtk.Menu()
-        package_type_preference_group = None
+        separator = Gtk.SeparatorMenuItem()
+        separator.show()
+        search_submenu.append(separator)
+
+        package_type_group = None
         for value, label in [
-            (PACKAGE_TYPE_PREFERENCE_ALL, _("Show all")),
-            (PACKAGE_TYPE_PREFERENCE_APT, _("Prefer system package")),
-            (PACKAGE_TYPE_PREFERENCE_FLATPAK, _("Prefer Flatpak")),
+            (PACKAGE_TYPE_PREFERENCE_ALL, _("Include all package types in results")),
+            (PACKAGE_TYPE_PREFERENCE_FLATPAK, _("Include only the Flatpak version of an app, if one exists")),
+            (PACKAGE_TYPE_PREFERENCE_APT, _("Include only the system package, if one exists")),
         ]:
-            package_type_preference_submenuitem = Gtk.RadioMenuItem.new_with_label(package_type_preference_group, label)
-            package_type_preference_group = package_type_preference_submenuitem.get_group()
-            package_type_preference_submenuitem.set_active(self.settings.get_string(PACKAGE_TYPE_PREFERENCE) == value)
-            package_type_preference_submenuitem.connect("toggled", self.set_package_type_preference, value)
-            package_type_preference_submenuitem.show()
-            package_type_preference_submenu.append(package_type_preference_submenuitem)
-
-        package_type_preference_menuitem = Gtk.MenuItem(label=_("Package type preference in search results"))
-        package_type_preference_menuitem.set_submenu(package_type_preference_submenu)
-        package_type_preference_menuitem.show()
-        submenu.append(package_type_preference_menuitem)
+            package_type_menuitem = Gtk.RadioMenuItem.new_with_label(package_type_group, label)
+            package_type_group = package_type_menuitem.get_group()
+            package_type_menuitem.set_active(self.settings.get_string(PACKAGE_TYPE_PREFERENCE) == value)
+            package_type_menuitem.connect("toggled", self.set_package_type_preference, value)
+            package_type_menuitem.show()
+            search_submenu.append(package_type_menuitem)
 
         separator = Gtk.SeparatorMenuItem()
         separator.show()

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -2542,14 +2542,6 @@ class Application(Gtk.Application):
                     is_match = True
                     pkginfo.search_tier = 0
                     break
-                if (search_in_summary and termsUpper in self.installer.get_summary(pkginfo, for_search=True).upper()):
-                    is_match = True
-                    pkginfo.search_tier = 100
-                    break
-                if(search_in_description and termsUpper in self.installer.get_description(pkginfo, for_search=True).upper()):
-                    is_match = True
-                    pkginfo.search_tier = 200
-                    break
                 # pkginfo.name for flatpaks is their id (org.foo.BarMaker), which
                 # may not actually contain the app's name. In this case their display
                 # names are better. The 'name' is still checked first above, because
@@ -2557,6 +2549,14 @@ class Application(Gtk.Application):
                 if pkginfo.pkg_hash.startswith("f") and all(piece in self.installer.get_display_name(pkginfo).upper() for piece in termsSplit):
                     is_match = True
                     pkginfo.search_tier = 0
+                    break
+                if (search_in_summary and termsUpper in self.installer.get_summary(pkginfo, for_search=True).upper()):
+                    is_match = True
+                    pkginfo.search_tier = 100
+                    break
+                if(search_in_description and termsUpper in self.installer.get_description(pkginfo, for_search=True).upper()):
+                    is_match = True
+                    pkginfo.search_tier = 200
                     break
                 break
 

--- a/usr/share/glib-2.0/schemas/com.linuxmint.install.gschema.xml
+++ b/usr/share/glib-2.0/schemas/com.linuxmint.install.gschema.xml
@@ -30,5 +30,15 @@
       <summary>Check this against the FlatpakInstallation to determine if we need to refresh the cache at startup.</summary>
       <description>name::uri::disabled tuples</description>
     </key>
+    <key type="s" name="search-package-type-preference">
+      <choices>
+        <choice value="all"/>
+        <choice value="apt"/>
+        <choice value="flatpak"/>
+      </choices>
+      <default>"all"</default>
+      <summary></summary>
+      <description></description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
The setting allows the user to choose a preferred package type, or keep the current behavior of no filtering (the default). When enabled, search results for applications that are provided as both apt and Flatpak packages will be filtered to only show the preferred package type. As before, the type can still be changed on the package details page before installation. Applications that only have a single package will still be shown regardless of type.

I also fixed an issue I noticed with the sorting of search results. Previously, if a Flatpak package's display name and summary/description matched the search terms, but the ID did not, then it would have been ranked as if there was a match in the summary/description but not in the name. (E.g. search for "document viewer", and notice the ranking of org.gnome.Evince, despite its display name literally being "Document Viewer".)

I bundled these two commits into the same PR, because they touch some of the same code.