### PR TITLE
Fix dot click error

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1517,7 +1517,7 @@ class Application(Gtk.Application):
         box.show_all()
 
     def on_dot_clicked(self, button, index):
-        self.start_slideshow_timer(self.banner_stack, button.get_parent())
+        self.start_slideshow_timer()
         self.banner_stack.set_visible_child_name(str(index))
         self.update_dot_buttons(index)
 


### PR DESCRIPTION
Was getting this when clicking on slideshow dots

```Traceback (most recent call last):
File "/usr/lib/linuxmint/mintinstall/mintinstall.py", line 1520, in on_dot_clicked
self.start_slideshow_timer(self.banner_stack, button.get_parent())
TypeError: Application.start_slideshow_timer() takes 1 positional argument but 3 were given
