### PR TITLE
Add software sources into submenu (Adding code from PR #382)

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1712,17 +1712,13 @@ class Application(Gtk.Application):
         self.load_featured()
         self.load_top_rated()
 
-
-
     def open_software_sources(self,_):
+        # Opens Mint's Software Sources and refreshes the cache afterwards
         def on_process_exited(proc, result):
             proc.wait_finish(result)
             self.refresh_cache()
-        """Opens Mint's Software Sources and refreshes the cache afterwards."""
-
-        # Launch mintsources
         p = Gio.Subprocess.new(["mintsources"], 0)
-        # Add a callback for when it finishes...
+        # Add a callback when we exit mintsources
         p.wait_async(None, on_process_exited)
 
     def should_show_pkginfo(self, pkginfo):

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1206,6 +1206,11 @@ class Application(Gtk.Application):
         self.refresh_cache_menuitem.set_sensitive(False)
         submenu.append(self.refresh_cache_menuitem)
 
+        software_sources_menuitem = Gtk.MenuItem(label=_("Software sources..."))
+        software_sources_menuitem.connect("activate", self.open_software_sources)
+        software_sources_menuitem.show()
+        submenu.append(software_sources_menuitem)
+
         self.prefs_menuitem = Gtk.MenuItem(label=_("Preferences"))
         self.prefs_menuitem.connect("activate", self.on_prefs_clicked)
         self.prefs_menuitem.show()
@@ -1706,6 +1711,19 @@ class Application(Gtk.Application):
         self.load_banner()
         self.load_featured()
         self.load_top_rated()
+
+
+
+    def open_software_sources(self,_):
+        def on_process_exited(proc, result):
+            proc.wait_finish(result)
+            self.refresh_cache()
+        """Opens Mint's Software Sources and refreshes the cache afterwards."""
+
+        # Launch mintsources
+        p = Gio.Subprocess.new(["mintsources"], 0)
+        # Add a callback for when it finishes...
+        p.wait_async(None, on_process_exited)
 
     def should_show_pkginfo(self, pkginfo):
         if pkginfo.pkg_hash.startswith("fp:") and not self.settings.get_boolean(prefs.ALLOW_UNVERIFIED_FLATPAKS):


### PR DESCRIPTION
This PR solves the issue brought up in PR #382 (Code taken from PR #382 as well). The application `mintsources` is added to the Software Manager application in a sub-menu, and runs alongside the Software Manager without freezing the main window. At `mintsources` exit, we update the list of packages. It works as intended (tested on LM 22 VM), although it takes about two refreshes of the Software Manager to list the packages from an added repository (in the demo below, I used Brave's repository).

Testing:
1. Add repo into `mintsources` (launched from Software Manager submenu), update APT cache, and exit `mintsources`
2. Wait for Software Manager to refresh
3. Package from added repo should show up

Demo:
![Peek 2024-08-14 07-14](https://github.com/user-attachments/assets/6c15dcc1-fb2e-4855-be87-f09cfb5350b6)


