### PR TITLE
Unify scrollbar positioning

### DIFF
--- a/resources/mintinstall.glade
+++ b/resources/mintinstall.glade
@@ -253,10 +253,6 @@
               <object class="GtkBox" id="box_landing">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-start">8</property>
-                <property name="margin-end">8</property>
-                <property name="margin-top">8</property>
-                <property name="margin-bottom">8</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
@@ -280,13 +276,16 @@
                               <object class="GtkBox" id="scroll_box">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="border-width">9</property>
                                 <property name="orientation">vertical</property>
                                 <child>
                                   <object class="GtkBox" id="box_banner">
                                     <property name="height-request">160</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="margin-right">10</property>
+                                    <property name="margin-start">3</property>
+                                    <property name="margin-end">3</property>
+                                    <property name="margin-top">3</property>
                                     <property name="margin-bottom">8</property>
                                     <property name="orientation">vertical</property>
                                     <child>
@@ -329,7 +328,6 @@
                                       <object class="GtkBox" id="box_featured">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="margin-right">10</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <placeholder/>
@@ -378,7 +376,6 @@
                                       <object class="GtkBox" id="box_categories">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="margin-right">10</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <placeholder/>
@@ -427,7 +424,6 @@
                                       <object class="GtkBox" id="box_top_rated">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="margin-right">10</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <placeholder/>
@@ -474,23 +470,43 @@
               <object class="GtkBox" id="box_list">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="margin-start">8</property>
-                <property name="margin-end">8</property>
-                <property name="margin-bottom">8</property>
                 <property name="orientation">vertical</property>
                 <property name="baseline-position">top</property>
                 <child>
-                  <object class="GtkLabel" id="label_cat_name">
+                  <object class="GtkBox" id="box_cat_label">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="xpad">6</property>
-                    <property name="ypad">12</property>
-                    <property name="xalign">0</property>
-                    <property name="yalign">0</property>
-                    <attributes>
-                      <attribute name="weight" value="bold"/>
-                      <attribute name="scale" value="1.2"/>
-                    </attributes>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkLabel" id="label_cat_name">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="xpad">12</property>
+                        <property name="ypad">12</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.2"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSeparator">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -516,6 +532,7 @@
                               <object class="GtkBox" id="box_cat_page">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="border-width">9</property>
                                 <property name="orientation">vertical</property>
                                 <child>
                                   <placeholder/>
@@ -578,14 +595,16 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkBox" id="box_subcategories">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-top">5</property>
+                    <property name="margin-start">9</property>
+                    <property name="margin-end">9</property>
+                    <property name="margin-bottom">9</property>
                     <child>
                       <placeholder/>
                     </child>
@@ -593,7 +612,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -1039,7 +1058,7 @@
                           <object class="GtkBox" id="box2">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="border-width">6</property>
+                            <property name="border-width">12</property>
                             <property name="orientation">vertical</property>
                             <property name="spacing">4</property>
                             <child>

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -2331,8 +2331,6 @@ class Application(Gtk.Application):
             listing = self.installer.cache.values()
             self.current_category = None
 
-        # don't just hide the flowbox, but also its parent
-        # self.subcat_flowbox.hide()
         subcat_box = self.builder.get_object("box_subcategories")
         subcat_box.hide()
         self.back_button.set_sensitive(True)

--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -2248,6 +2248,7 @@ class Application(Gtk.Application):
     def show_category(self, category):
         self.current_pkginfo = None
 
+        cat_box = self.builder.get_object("box_cat_label")
         label = self.builder.get_object("label_cat_name")
 
         self.current_category = category
@@ -2257,12 +2258,14 @@ class Application(Gtk.Application):
         self.back_button.set_sensitive(True)
 
         label.set_text(self.current_category.name)
-        label.show()
 
         if category.parent:
             self.show_subcategories(category.parent)
         else:
             self.show_subcategories(category)
+
+        label.show()
+        cat_box.show()
 
         self.show_packages(category.pkginfos, from_search=False)
 
@@ -2285,6 +2288,8 @@ class Application(Gtk.Application):
                 child = SubcategoryFlowboxChild(cat, is_all=False, active=self.current_category == cat)
                 self.subcat_flowbox.add(child)
 
+        subcat_box = self.builder.get_object("box_subcategories")
+        subcat_box.show()
         self.subcat_flowbox.show_all()
 
     def on_subcategory_selected(self, flowbox, child, data=None):
@@ -2308,7 +2313,7 @@ class Application(Gtk.Application):
         if not self.gui_ready:
             return False
 
-        label = self.builder.get_object("label_cat_name")
+        label = self.builder.get_object("box_cat_label")
         label.hide()
 
         XApp.set_window_progress(self.main_window, 0)
@@ -2326,7 +2331,10 @@ class Application(Gtk.Application):
             listing = self.installer.cache.values()
             self.current_category = None
 
-        self.subcat_flowbox.hide()
+        # don't just hide the flowbox, but also its parent
+        # self.subcat_flowbox.hide()
+        subcat_box = self.builder.get_object("box_subcategories")
+        subcat_box.hide()
         self.back_button.set_sensitive(True)
         self.previous_page = self.PAGE_LANDING
         if self.page_stack.get_visible_child_name() != self.PAGE_SEARCHING:


### PR DESCRIPTION
Hi!

Currently, the scrollbar position and margins of scrollable content vary between different views of the main GtkStack. Especially when not using overlay scrollbars, the scrollbars look a bit out of place compared to other XApps. I tried to improve the overall visual consistency by adjusting the widget spacing.

Before:
![mintinstall-scrollbar-search](https://github.com/user-attachments/assets/8b8530f7-bb0b-47f5-88af-75c02a475eaf)

After:
![mintinstall-scrollbar-search-after](https://github.com/user-attachments/assets/46cd8e50-7886-4986-924e-e32c8b50757a)
