### PR TITLE
Use auto resource management for license file

### DIFF
--- a/usr/lib/linuxmint/mintinstall/mintinstall.py
+++ b/usr/lib/linuxmint/mintinstall/mintinstall.py
@@ -1780,12 +1780,8 @@ class Application(Gtk.Application):
         dlg.set_program_name("mintinstall")
         dlg.set_comments(_("Software Manager"))
         try:
-            h = open('/usr/share/common-licenses/GPL', 'r')
-            s = h.readlines()
-            gpl = ""
-            for line in s:
-                gpl += line
-            h.close()
+            with open('/usr/share/common-licenses/GPL', 'r') as h:
+                gpl = h.read()
             dlg.set_license(gpl)
         except Exception as e:
             print(e)


### PR DESCRIPTION
Replaced manual resource management for the license file with the `with` statement to ensure it always gets closed. Additionally, since concatenating the results of `readlines()` reconstructs the original file content, `read() `is used directly instead for simplicity and efficiency.