### PR TITLE
[WIP] Optimize package search

### DIFF
--- a/resources/mintinstall.glade
+++ b/resources/mintinstall.glade
@@ -174,19 +174,6 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">image-loading-symbolic</property>
-                    <property name="icon_size">6</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -195,6 +182,21 @@
                       <attribute name="weight" value="bold"/>
                       <attribute name="scale" value="1.2"/>
                     </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner">
+                    <property name="visible">True</property>
+                    <property name="active">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="height-request">50</property>
+                    <property name="width-request">50</property>
+                    <property name="halign">center</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1957,11 +1959,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSpinner" id="loading_spinner1">
-                    <property name="height-request">50</property>
-                    <property name="visible">True</property>
+                  <object class="GtkBox" id="search_progress_bar">
+                    <property name="width-request">200</property>
                     <property name="can-focus">False</property>
-                    <property name="active">True</property>
+                    <property name="height-request">12</property>
+                    <property name="visible">True</property>
+                    <property name="halign">center</property>
+                    <property name="margin-top">10</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
- call `installer.get_description()` with `for_search=True` for faster search (I'm not 100% sure what's the difference in terms of searching but it seems appropriate and the performance gain is very noticeable*)
- cache name, summary, description etc. for each package for faster consequent searches
- pre-generate search cache in background when installer is ready
- reset page to landing if search input is empty
- cancel current search if user navigated back to landing
- minor performance improvements (iterate through packages without redundant allocations)

UPD:
- improve search performance more with CooperativeIterator
- show progress bar on package search instead of spinner

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ca5aed61-cf3e-4e3d-8096-eda964027c0a" /> | <video src="https://github.com/user-attachments/assets/1d2c7135-6847-4c9b-bceb-46bbbfaf1420" /> |

--
*) 12s vs 200s on my machine