### PR TITLE
mintinstall: add command line option "show"

### DIFF
--- a/usr/bin/mintinstall
+++ b/usr/bin/mintinstall
@@ -2,6 +2,7 @@
 
 import subprocess
 import os
+import sys
 
 # Remove any obsolete configuration file
 obsolete_path = os.path.expanduser("~/.config/autostart/mintinstall-update-flatpak.desktop")
@@ -11,4 +12,4 @@ if os.path.exists(obsolete_path):
 	except:
 		pass
 
-subprocess.call("/usr/lib/linuxmint/mintinstall/mintinstall.py")
+subprocess.call(["/usr/lib/linuxmint/mintinstall/mintinstall.py"] + sys.argv[1:])


### PR DESCRIPTION
Add command line option `mintinstall show <pkg_name>` to open mintinstall on the details page of a specific package. This can be used e.g. in a menu applet to show information about a particular app.